### PR TITLE
Batch info out of metadata

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -455,3 +455,7 @@ def test_design_matrix():
         os.remove(matrix_filename)
         os.remove('{}.yaml'.format(uuid))
         os.remove('.matrix_uuids')
+
+
+
+

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -125,8 +125,6 @@ def test_build_labels_query():
         create_features_and_labels_schemas(engine, features_tables, labels)
 
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime(2017, 3, 1, 12, 0),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -172,8 +170,6 @@ def test_write_to_csv():
         create_features_and_labels_schemas(engine, features_tables, labels)
 
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime(2017, 3, 1, 12, 0),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -214,8 +210,6 @@ def test_make_entity_dates_table():
         create_features_and_labels_schemas(engine, features_tables, labels)
 
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime(2017, 3, 1, 12, 0),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -282,8 +276,6 @@ def test_build_features_query():
         create_features_and_labels_schemas(engine, features_tables, labels)
 
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime(2017, 3, 1, 12, 0),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -313,8 +305,6 @@ def test_build_features_query():
 class TestMergeFeatureCSVs(TestCase):
     def test_merge_feature_csvs(self):
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime(2017, 3, 1, 12, 0),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -378,8 +368,6 @@ class TestMergeFeatureCSVs(TestCase):
 
     def test_badinput(self):
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime(2017, 3, 1, 12, 0),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -438,8 +426,6 @@ def test_design_matrix():
                  datetime.datetime(2016, 3, 1, 0, 0)]
 
         matrix_maker = Architect(
-            batch_id = 2,
-            batch_timestamp = datetime.datetime.now(),
             beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
             label_names = ['booking'],
             label_types = ['binary'],
@@ -457,7 +443,8 @@ def test_design_matrix():
         uuid = matrix_maker.design_matrix(
             matrix_definition = matrix_dates,
             label_name = 'booking',
-            label_type = 'binary'
+            label_type = 'binary',
+            completed_uuids = set()
         )
 
         matrix_filename = '{}.csv'.format(uuid)

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -20,26 +20,26 @@ class Architect(object):
 
     def chop_data(self, matrix_set_definitions):
         updated_definitions = []
-        uuids = set()
+        completed_uuids = set()
         for matrix_set in matrix_set_definitions:
             for label_name, label_type in itertools.product(self.label_names, self.label_types):
                 matrix_set['train_uuid'] = self.design_matrix(
                     matrix_definition = matrix_set['train_matrix'],
                     label_name = label_name,
                     label_type = label_type,
-                    completed_uuids = uuids
+                    completed_uuids = completed_uuids
                 )
-                uuids.add(matrix_set['train_uuid'])
+                completed_uuids.add(matrix_set['train_uuid'])
                 test_uuids = []
                 for test_matrix in matrix_set['test_matrices']:
                     test_uuid = self.design_matrix(
                         matrix_definition = test_matrix,
                         label_name = label_name,
                         label_type = label_type,
-                        completed_uuids = uuids
+                        completed_uuids = completed_uuids
                     )
                     test_uuids.append(test_uuid)
-                    uuids.add(test_uuid)
+                    completed_uuids.add(test_uuid)
                 matrix_set['test_uuids'] = test_uuids
                 updated_definitions.append(matrix_set)
 


### PR DESCRIPTION
This removes branch info from metadata to reduce the amount of disk space needed for storing matrices. Each repo will only have the most up-to-date values for the columns/rows included in the matrix.