### PR TITLE
correct indices in metadata

### DIFF
--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -244,7 +244,7 @@ class Architect(object):
             'end_time': matrix_definition['matrix_end_time'],
 
             # columns
-            'indices': ['entity_id', 'as_of_time'],
+            'indices': ['entity_id', 'as_of_date'],
             'feature_names': utils.feature_list(feature_dictionary),
             'label_name': label_name,
 


### PR DESCRIPTION
fixes bug where index name in metadata doesn't match column name in matrix