### PR TITLE
Add test duration & impute matrix begin time when before modeling start

### DIFF
--- a/tests/test_timechop.py
+++ b/tests/test_timechop.py
@@ -14,7 +14,8 @@ class test_calculate_update_times(TestCase):
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2013, 1, 1, 0, 0),
             update_window = '1 year',
-            look_back_durations = ['1 year']
+            look_back_durations = ['1 year'],
+            test_durations = ['1 month']
         )
         result = chopper.calculate_matrix_end_times('1 year')
         assert(result == expected_result)
@@ -25,7 +26,8 @@ class test_calculate_update_times(TestCase):
             modeling_start_time = datetime.datetime(2011, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2011, 2, 1, 0, 0),
             update_window = '5 months',
-            look_back_durations = ['1 year']
+            look_back_durations = ['1 year'],
+            test_durations = ['1 month']
         )
         with self.assertRaises(ValueError):
             chopper.calculate_matrix_end_times('1 year')
@@ -49,7 +51,8 @@ def test_calculate_as_of_times():
         modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
         modeling_end_time = datetime.datetime(2012, 1, 1, 0, 0),
         update_window = '1 year',
-        look_back_durations = ['10 days', '1 year']
+        look_back_durations = ['10 days', '1 year'],
+        test_durations = ['1 month']
     )
     result = chopper.calculate_as_of_times(
         matrix_start_time = datetime.datetime(2011, 1, 1, 0, 0),
@@ -92,7 +95,8 @@ class test_generate_matrix_definition(TestCase):
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 11, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['5 days']
+            look_back_durations = ['5 days'],
+            test_durations = ['5 days']
         )
         result = chopper.generate_matrix_definition(
             train_matrix_end_time = datetime.datetime(2010, 1, 6, 0, 0),
@@ -104,7 +108,7 @@ class test_generate_matrix_definition(TestCase):
         expected_result = {
             'beginning_of_time': datetime.datetime(1990, 1, 1, 0, 0),
             'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
-            'modeling_end_time': datetime.datetime(2010, 1, 11, 0, 0),
+            'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
             'train_matrix': {
                 'matrix_start_time': datetime.datetime(2010, 1, 1, 0, 0),
                 'matrix_end_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -116,24 +120,47 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 5, 0, 0)
                 ]
             },
-            'test_matrices': [{
-                'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
-                'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
-                'as_of_times': [
-                    datetime.datetime(2010, 1, 6, 0, 0),
-                    datetime.datetime(2010, 1, 7, 0, 0),
-                    datetime.datetime(2010, 1, 8, 0, 0),
-                    datetime.datetime(2010, 1, 9, 0, 0),
-                    datetime.datetime(2010, 1, 10, 0, 0)
-                ]
-            }]
+            'test_matrices': [
+                {
+                    'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
+                    'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
+                    'as_of_times': [
+                        datetime.datetime(2010, 1, 6, 0, 0),
+                        datetime.datetime(2010, 1, 7, 0, 0),
+                        datetime.datetime(2010, 1, 8, 0, 0),
+                        datetime.datetime(2010, 1, 9, 0, 0),
+                        datetime.datetime(2010, 1, 10, 0, 0)
+                    ]
+                },
+                {
+                    'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
+                    'matrix_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+                    'as_of_times': [
+                        datetime.datetime(2010, 1, 6, 0, 0),
+                        datetime.datetime(2010, 1, 7, 0, 0),
+                        datetime.datetime(2010, 1, 8, 0, 0),
+                        datetime.datetime(2010, 1, 9, 0, 0),
+                        datetime.datetime(2010, 1, 10, 0, 0),
+                        datetime.datetime(2010, 1, 11, 0, 0),
+                        datetime.datetime(2010, 1, 12, 0, 0),
+                        datetime.datetime(2010, 1, 13, 0, 0),
+                        datetime.datetime(2010, 1, 14, 0, 0),
+                        datetime.datetime(2010, 1, 15, 0, 0)
+                    ]
+                }
+            ]
         }
+        # this tests that (a) 5 and 10 day prediction duration return distinct
+        # test matrices in a list and (b) 10 and 15 day durations produce
+        # redundanct test matrices (because 15 days after training period is 
+        # beyond the end of the modeling time), only one of which is returned
         chopper = Inspections(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-            modeling_end_time = datetime.datetime(2010, 1, 11, 0, 0),
+            modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['10 days']
+            look_back_durations = ['10 days'],
+            test_durations = ['5 days', '10 days', '15 days']
         )
         result = chopper.generate_matrix_definition(
             train_matrix_end_time = datetime.datetime(2010, 1, 6, 0, 0),
@@ -162,18 +189,13 @@ class test_chop_time(TestCase):
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
-                    'matrix_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+                    'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 7, 0, 0),
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
-                        datetime.datetime(2010, 1, 10, 0, 0),
-                        datetime.datetime(2010, 1, 11, 0, 0),
-                        datetime.datetime(2010, 1, 12, 0, 0),
-                        datetime.datetime(2010, 1, 13, 0, 0),
-                        datetime.datetime(2010, 1, 14, 0, 0),
-                        datetime.datetime(2010, 1, 15, 0, 0)
+                        datetime.datetime(2010, 1, 10, 0, 0)
                     ]
                 }]
                 
@@ -211,7 +233,8 @@ class test_chop_time(TestCase):
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['5 days']
+            look_back_durations = ['5 days'],
+            test_durations = ['5 days']
         )
         result = chopper.chop_time()
         assert(result == expected_result)
@@ -235,18 +258,13 @@ class test_chop_time(TestCase):
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
-                    'matrix_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+                    'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 7, 0, 0),
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
-                        datetime.datetime(2010, 1, 10, 0, 0),
-                        datetime.datetime(2010, 1, 11, 0, 0),
-                        datetime.datetime(2010, 1, 12, 0, 0),
-                        datetime.datetime(2010, 1, 13, 0, 0),
-                        datetime.datetime(2010, 1, 14, 0, 0),
-                        datetime.datetime(2010, 1, 15, 0, 0)
+                        datetime.datetime(2010, 1, 10, 0, 0)
                     ]
                 }]
             },
@@ -286,7 +304,8 @@ class test_chop_time(TestCase):
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['7 days']
+            look_back_durations = ['7 days'],
+            test_durations = ['5 days']
         )
         
         with warnings.catch_warnings(record = True) as w:
@@ -314,16 +333,13 @@ class test_chop_time(TestCase):
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 8, 0, 0),
-                    'matrix_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+                    'matrix_end_time': datetime.datetime(2010, 1, 13, 0, 0),
                     'as_of_times': [
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
                         datetime.datetime(2010, 1, 10, 0, 0),
                         datetime.datetime(2010, 1, 11, 0, 0),
-                        datetime.datetime(2010, 1, 12, 0, 0),
-                        datetime.datetime(2010, 1, 13, 0, 0),
-                        datetime.datetime(2010, 1, 14, 0, 0),
-                        datetime.datetime(2010, 1, 15, 0, 0)
+                        datetime.datetime(2010, 1, 12, 0, 0)
                     ]
                 }]
             }
@@ -334,7 +350,8 @@ class test_chop_time(TestCase):
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '8 days',
-            look_back_durations = ['5 days']
+            look_back_durations = ['5 days'],
+            test_durations = ['5 days']
         )
         
         with warnings.catch_warnings(record = True) as w:
@@ -354,5 +371,6 @@ class test__init__(TestCase):
                 modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
                 update_window = '6 days',
-                look_back_durations = ['5 days']
+                look_back_durations = ['5 days'],
+                test_durations = ['5 days']
             )


### PR DESCRIPTION
This PR merges in changes from #28 (now closed without merging) and supersedes it.

Institutes the following changes:

- When train matrix start time is before modeling start time, force matrix start time to be modeling start time; this is necessary for long look back durations (e.g., including all data from modeling period in final training matrix)
- Constructor requires a `test_durations` parameter. This is a list of lengths of test matrices. Matrix definitions return a test matrix for each test duration except when the final train matrix does not leave enough time, in which case, only unique test matrices are returned.