### PR TITLE
Pass matrix directory as input [Resolves #8]

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -3,6 +3,7 @@ from tests.utils import create_features_and_labels_schemas
 from tests.utils import create_entity_date_df
 from tests.utils import convert_string_column_to_date
 from tests.utils import NamedTempFile
+from tests.utils import TemporaryDirectory
 import testing.postgresql
 import csv
 import datetime
@@ -122,41 +123,43 @@ def test_build_labels_query():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         create_features_and_labels_schemas(engine, features_tables, labels)
-        matrix_maker = Architect(
-            beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-            label_names = ['booking'],
-            label_types = ['binary'],
-            db_config = db_config,
-            user_metadata = {},
-            engine = engine
-        )       
+        with TemporaryDirectory() as temp_dir:
+            matrix_maker = Architect(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = engine
+            )       
 
-        # get the queries and test them
-        for date in dates:
-            date = date.date()
-            df = labels_df[labels_df['label_name'] == label_name]
-            df = df[labels_df['label_type'] == label_type]
-            df = df[labels_df['prediction_window'] == '1 month']
-            print(date)
-            df = df[labels_df['as_of_date'] == date]
-            df = df[['entity_id', 'as_of_date', 'label']]
-            df = df.rename(
-                columns = {
-                    "entity_id": "entity_id",
-                    "as_of_date": "as_of_date",
-                    "label": label_name
-                }
-            )
-            df = df.reset_index(drop = True)
-            query = matrix_maker.build_labels_query(
-                as_of_times = [date],
-                label_type = label_type,
-                label_name = label_name,
-                final_column = ', label as {}'.format(label_name)
-            )
-            result = pd.read_sql(query, engine)
-            test = (result == df)
-            assert(test.all().all())
+            # get the queries and test them
+            for date in dates:
+                date = date.date()
+                df = labels_df[labels_df['label_name'] == label_name]
+                df = df[labels_df['label_type'] == label_type]
+                df = df[labels_df['prediction_window'] == '1 month']
+                print(date)
+                df = df[labels_df['as_of_date'] == date]
+                df = df[['entity_id', 'as_of_date', 'label']]
+                df = df.rename(
+                    columns = {
+                        "entity_id": "entity_id",
+                        "as_of_date": "as_of_date",
+                        "label": label_name
+                    }
+                )
+                df = df.reset_index(drop = True)
+                query = matrix_maker.build_labels_query(
+                    as_of_times = [date],
+                    label_type = label_type,
+                    label_name = label_name,
+                    final_column = ', label as {}'.format(label_name)
+                )
+                result = pd.read_sql(query, engine)
+                test = (result == df)
+                assert(test.all().all())
 
 def test_write_to_csv():
     """ Test the write_to_csv function by checking whether the csv contains the
@@ -167,28 +170,30 @@ def test_write_to_csv():
         engine = create_engine(postgresql.url())
         create_features_and_labels_schemas(engine, features_tables, labels)
 
-        matrix_maker = Architect(
-            beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-            label_names = ['booking'],
-            label_types = ['binary'],
-            db_config = db_config,
-            user_metadata = {},
-            engine = engine
-        )
+        with TemporaryDirectory() as temp_dir:
+            matrix_maker = Architect(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = engine
+            )
 
-        # for each table, check that corresponding csv has the correct # of rows
-        for table in features_tables:
-            with NamedTempFile() as f:
-                matrix_maker.write_to_csv(
-                    '''
-                        select * 
-                        from features.features{}
-                    '''.format(features_tables.index(table)),
-                    f.name
-                )
-                f.seek(0)
-                reader = csv.reader(f)
-                assert(len([row for row in reader]) == len(table) + 1)
+            # for each table, check that corresponding csv has the correct # of rows
+            for table in features_tables:
+                with NamedTempFile() as f:
+                    matrix_maker.write_to_csv(
+                        '''
+                            select * 
+                            from features.features{}
+                        '''.format(features_tables.index(table)),
+                        f.name
+                    )
+                    f.seek(0)
+                    reader = csv.reader(f)
+                    assert(len([row for row in reader]) == len(table) + 1)
 
 
 def test_make_entity_date_table():
@@ -207,41 +212,43 @@ def test_make_entity_date_table():
         engine = create_engine(postgresql.url())
         create_features_and_labels_schemas(engine, features_tables, labels)
 
-        matrix_maker = Architect(
-            beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-            label_names = ['booking'],
-            label_types = ['binary'],
-            db_config = db_config,
-            user_metadata = {},
-            engine = engine
-        )
+        with TemporaryDirectory() as temp_dir:
+            matrix_maker = Architect(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = engine
+            )
 
-        # call the function to test the creation of the table
-        matrix_maker.make_entity_date_table(
-            as_of_times = dates,
-            label_type = 'binary',
-            label_name = 'booking',
-            feature_table_names = ['features0', 'features1'],
-            matrix_type = 'train'
-        )
+            # call the function to test the creation of the table
+            matrix_maker.make_entity_date_table(
+                as_of_times = dates,
+                label_type = 'binary',
+                label_name = 'booking',
+                feature_table_names = ['features0', 'features1'],
+                matrix_type = 'train'
+            )
 
-        # read in the table
-        result = pd.read_sql(
-            "select * from features.tmp_entity_date order by entity_id, as_of_date",
-            engine
-        )
-        labels_df = pd.read_sql('select * from labels.labels', engine)
+            # read in the table
+            result = pd.read_sql(
+                "select * from features.tmp_entity_date order by entity_id, as_of_date",
+                engine
+            )
+            labels_df = pd.read_sql('select * from labels.labels', engine)
 
-        # compare the table to the test dataframe
-        print("ids_dates")
-        for i, row in ids_dates.iterrows():
-            print(row.values)
-        print("result")
-        for i, row in result.iterrows():
-            print(row.values)
-        test = (result == ids_dates)
-        print(test)
-        assert(test.all().all())
+            # compare the table to the test dataframe
+            print("ids_dates")
+            for i, row in ids_dates.iterrows():
+                print(row.values)
+            print("result")
+            for i, row in result.iterrows():
+                print(row.values)
+            test = (result == ids_dates)
+            print(test)
+            assert(test.all().all())
 
 def test_build_outer_join_query():
     """ 
@@ -273,152 +280,158 @@ def test_build_outer_join_query():
         engine = create_engine(postgresql.url())
         create_features_and_labels_schemas(engine, features_tables, labels)
 
-        matrix_maker = Architect(
-            beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-            label_names = ['booking'],
-            label_types = ['binary'],
-            db_config = db_config,
-            user_metadata = {},
-            engine = engine
-        )
-
-        # make the entity-date table
-        matrix_maker.make_entity_date_table(
-            as_of_times = dates,
-            label_type = 'binary',
-            label_name = 'booking',
-            feature_table_names = ['features0', 'features1'],
-            matrix_type = 'train'
-        )
-
-        # get the queries and test them
-        for table_number, df in enumerate(features_dfs):
-            table_name = 'features{}'.format(table_number)
-            df = df.fillna(0)
-            query = matrix_maker.build_outer_join_query(
-                as_of_times = dates,
-                right_table_name = 'features.{}'.format(table_name),
-                right_column_selections = matrix_maker._format_imputations(
-                    ['f1', 'f2']
-                )
+        with TemporaryDirectory() as temp_dir:
+            matrix_maker = Architect(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = engine
             )
-            result = pd.read_sql(query, engine)
-            test = (result == df)
-            assert(test.all().all())
+
+            # make the entity-date table
+            matrix_maker.make_entity_date_table(
+                as_of_times = dates,
+                label_type = 'binary',
+                label_name = 'booking',
+                feature_table_names = ['features0', 'features1'],
+                matrix_type = 'train'
+            )
+
+            # get the queries and test them
+            for table_number, df in enumerate(features_dfs):
+                table_name = 'features{}'.format(table_number)
+                df = df.fillna(0)
+                query = matrix_maker.build_outer_join_query(
+                    as_of_times = dates,
+                    right_table_name = 'features.{}'.format(table_name),
+                    right_column_selections = matrix_maker._format_imputations(
+                        ['f1', 'f2']
+                    )
+                )
+                result = pd.read_sql(query, engine)
+                test = (result == df)
+                assert(test.all().all())
 
 class TestMergeFeatureCSVs(TestCase):
     def test_merge_feature_csvs(self):
-        matrix_maker = Architect(
-            beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-            label_names = ['booking'],
-            label_types = ['binary'],
-            db_config = db_config,
-            user_metadata = {},
-            engine = None
-        )
-        rowlists = [
-            [
-                ('entity_id', 'date', 'label'),
-                (1, 2, True),
-                (4, 5, False),
-                (7, 8, True),
-            ],
-            [
-                ('entity_id', 'date', 'f1'),
-                (1, 2, 3),
-                (4, 5, 6),
-                (7, 8, 9),
-            ],
-            [
-                ('entity_id', 'date', 'f2'),
-                (1, 2, 3),
-                (4, 5, 9),
-                (7, 8, 15),
-            ],
-            [
-                ('entity_id', 'date', 'f3'),
-                (1, 2, 2),
-                (4, 5, 20),
-                (7, 8, 56),
-            ],
-        ]
+        with TemporaryDirectory() as temp_dir:
+            matrix_maker = Architect(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = None
+            )
+            rowlists = [
+                [
+                    ('entity_id', 'date', 'label'),
+                    (1, 2, True),
+                    (4, 5, False),
+                    (7, 8, True),
+                ],
+                [
+                    ('entity_id', 'date', 'f1'),
+                    (1, 2, 3),
+                    (4, 5, 6),
+                    (7, 8, 9),
+                ],
+                [
+                    ('entity_id', 'date', 'f2'),
+                    (1, 2, 3),
+                    (4, 5, 9),
+                    (7, 8, 15),
+                ],
+                [
+                    ('entity_id', 'date', 'f3'),
+                    (1, 2, 2),
+                    (4, 5, 20),
+                    (7, 8, 56),
+                ],
+            ]
 
-        sourcefiles = []
-        for rows in rowlists:
+            sourcefiles = []
+            for rows in rowlists:
 
-            f = NamedTempFile()
-            sourcefiles.append(f)
-            writer = csv.writer(f)
-            for row in rows:
-                writer.writerow(row)
-            f.seek(0)
-        try:
-            with NamedTempFile() as outfile:
-                matrix_maker.merge_feature_csvs(
-                    [f.name for f in sourcefiles],
-                    outfile.name
-                )
-                reader = csv.reader(outfile)
-                result = [row for row in reader]
-                self.assertEquals(result, [
-                    ['entity_id', 'date', 'f1', 'f2', 'f3','label'],
-                    ['1', '2', '3', '3', '2', 'True'],
-                    ['4', '5', '6', '9', '20', 'False'],
-                    ['7', '8', '9', '15', '56', 'True']
-                ])
-        finally:
-            for sourcefile in sourcefiles:
-                sourcefile.close()
-
-
-    def test_badinput(self):
-        matrix_maker = Architect(
-            beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-            label_names = ['booking'],
-            label_types = ['binary'],
-            db_config = db_config,
-            user_metadata = {},
-            engine = None
-        )
-        rowlists = [
-            [
-                ('entity_id', 'date', 'f1'),
-                (1, 3, 3),
-                (4, 5, 6),
-                (7, 8, 9),
-            ],
-            [
-                ('entity_id', 'date', 'f2'),
-                (1, 2, 3),
-                (4, 5, 9),
-                (7, 8, 15),
-            ],
-            [
-                ('entity_id', 'date', 'f3'),
-                (1, 2, 2),
-                (4, 5, 20),
-                (7, 8, 56),
-            ],
-        ]
-
-        sourcefiles = []
-        for rows in rowlists:
-            f = NamedTempFile()
-            sourcefiles.append(f)
-            writer = csv.writer(f)
-            for row in rows:
-                writer.writerow(row)
-            f.seek(0)
-        try:
-            with NamedTempFile() as outfile:
-                with self.assertRaises(ValueError):
+                f = NamedTempFile()
+                sourcefiles.append(f)
+                writer = csv.writer(f)
+                for row in rows:
+                    writer.writerow(row)
+                f.seek(0)
+            try:
+                with NamedTempFile() as outfile:
                     matrix_maker.merge_feature_csvs(
                         [f.name for f in sourcefiles],
                         outfile.name
                     )
-        finally:
-            for sourcefile in sourcefiles:
-                sourcefile.close()
+                    reader = csv.reader(outfile)
+                    result = [row for row in reader]
+                    self.assertEquals(result, [
+                        ['entity_id', 'date', 'f1', 'f2', 'f3','label'],
+                        ['1', '2', '3', '3', '2', 'True'],
+                        ['4', '5', '6', '9', '20', 'False'],
+                        ['7', '8', '9', '15', '56', 'True']
+                    ])
+            finally:
+                for sourcefile in sourcefiles:
+                    sourcefile.close()
+
+
+    def test_badinput(self):
+        with TemporaryDirectory() as temp_dir:
+            matrix_maker = Architect(
+                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                label_names = ['booking'],
+                label_types = ['binary'],
+                db_config = db_config,
+                matrix_directory = temp_dir,
+                user_metadata = {},
+                engine = None
+            )
+            rowlists = [
+                [
+                    ('entity_id', 'date', 'f1'),
+                    (1, 3, 3),
+                    (4, 5, 6),
+                    (7, 8, 9),
+                ],
+                [
+                    ('entity_id', 'date', 'f2'),
+                    (1, 2, 3),
+                    (4, 5, 9),
+                    (7, 8, 15),
+                ],
+                [
+                    ('entity_id', 'date', 'f3'),
+                    (1, 2, 2),
+                    (4, 5, 20),
+                    (7, 8, 56),
+                ],
+            ]
+
+            sourcefiles = []
+            for rows in rowlists:
+                f = NamedTempFile()
+                sourcefiles.append(f)
+                writer = csv.writer(f)
+                for row in rows:
+                    writer.writerow(row)
+                f.seek(0)
+            try:
+                with NamedTempFile() as outfile:
+                    with self.assertRaises(ValueError):
+                        matrix_maker.merge_feature_csvs(
+                            [f.name for f in sourcefiles],
+                            outfile.name
+                        )
+            finally:
+                for sourcefile in sourcefiles:
+                    sourcefile.close()
 
 class TestDesignMatrix(object):
     def test_train_matrix(self):
@@ -431,41 +444,39 @@ class TestDesignMatrix(object):
                      datetime.datetime(2016, 2, 1, 0, 0),
                      datetime.datetime(2016, 3, 1, 0, 0)]
 
-            matrix_maker = Architect(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                user_metadata = {},
-                engine = engine
-            )
-            matrix_dates = {
-                'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                'as_of_times': dates
-            }
-            feature_dictionary = {
-                'features0': ['f1', 'f2'],
-                'features1': ['f1', 'f2'],
-            }
+            with TemporaryDirectory() as temp_dir:
+                matrix_maker = Architect(
+                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    label_names = ['booking'],
+                    label_types = ['binary'],
+                    db_config = db_config,
+                    matrix_directory = temp_dir,
+                    user_metadata = {},
+                    engine = engine
+                )
+                matrix_dates = {
+                    'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'as_of_times': dates
+                }
+                feature_dictionary = {
+                    'features0': ['f1', 'f2'],
+                    'features1': ['f1', 'f2'],
+                }
 
-            uuid = matrix_maker.design_matrix(
-                matrix_definition = matrix_dates,
-                label_name = 'booking',
-                label_type = 'binary',
-                feature_dictionary = feature_dictionary,
-                completed_uuids = set(),
-                matrix_type = 'train'
-            )
+                uuid = matrix_maker.design_matrix(
+                    matrix_definition = matrix_dates,
+                    label_name = 'booking',
+                    label_type = 'binary',
+                    feature_dictionary = feature_dictionary,
+                    completed_uuids = set(),
+                    matrix_type = 'train'
+                )
 
-            matrix_filename = '{}.csv'.format(uuid)
-            with open(matrix_filename, 'r') as f:
-                reader = csv.reader(f)
-                assert(len([row for row in reader]) == 12)
-
-            os.remove(matrix_filename)
-            os.remove('{}.yaml'.format(uuid))
-            os.remove('.matrix_uuids')
+                matrix_filename = '{}.csv'.format(uuid)
+                with open(matrix_filename, 'r') as f:
+                    reader = csv.reader(f)
+                    assert(len([row for row in reader]) == 12)
 
     def test_test_matrix(self):
         with testing.postgresql.Postgresql() as postgresql:
@@ -477,40 +488,37 @@ class TestDesignMatrix(object):
                      datetime.datetime(2016, 2, 1, 0, 0),
                      datetime.datetime(2016, 3, 1, 0, 0)]
 
-            matrix_maker = Architect(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                user_metadata = {},
-                engine = engine
-            )
+            with TemporaryDirectory() as temp_dir:
+                matrix_maker = Architect(
+                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    label_names = ['booking'],
+                    label_types = ['binary'],
+                    db_config = db_config,
+                    matrix_directory = temp_dir,
+                    user_metadata = {},
+                    engine = engine
+                )
 
-            matrix_dates = {
-                'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                'as_of_times': dates
-            }
-            feature_dictionary = {
-                'features0': ['f1', 'f2'],
-                'features1': ['f1', 'f2'],
-            }
+                matrix_dates = {
+                    'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'as_of_times': dates
+                }
+                feature_dictionary = {
+                    'features0': ['f1', 'f2'],
+                    'features1': ['f1', 'f2'],
+                }
 
-            uuid = matrix_maker.design_matrix(
-                matrix_definition = matrix_dates,
-                label_name = 'booking',
-                label_type = 'binary',
-                feature_dictionary = feature_dictionary,
-                completed_uuids = set(),
-                matrix_type = 'test'
-            )
+                uuid = matrix_maker.design_matrix(
+                    matrix_definition = matrix_dates,
+                    label_name = 'booking',
+                    label_type = 'binary',
+                    feature_dictionary = feature_dictionary,
+                    completed_uuids = set(),
+                    matrix_type = 'test'
+                )
 
-            matrix_filename = '{}.csv'.format(uuid)
-            with open(matrix_filename, 'r') as f:
-                reader = csv.reader(f)
-                assert(len([row for row in reader]) == 13)
-
-            os.remove(matrix_filename)
-            os.remove('{}.yaml'.format(uuid))
-            os.remove('.matrix_uuids')
-
+                matrix_filename = '{}.csv'.format(uuid)
+                with open(matrix_filename, 'r') as f:
+                    reader = csv.reader(f)
+                    assert(len([row for row in reader]) == 13)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
 import pandas as pd
 import datetime
+import shutil
 import sys
 import tempfile
+from contextlib import contextmanager
 
 
 def convert_string_column_to_date(column):
@@ -91,3 +93,11 @@ def NamedTempFile():
         return tempfile.NamedTemporaryFile(mode='w+', newline='')
     else:
         return tempfile.NamedTemporaryFile()
+
+@contextmanager
+def TemporaryDirectory():
+    name = tempfile.mkdtemp()
+    try:
+        yield name
+    finally:
+        shutil.rmtree(name)

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -9,11 +9,12 @@ from . import utils
 class Architect(object):
 
     def __init__(self, beginning_of_time, label_names, label_types, db_config,
-                 user_metadata, engine):
+                 matrix_directory, user_metadata, engine):
         self.beginning_of_time = beginning_of_time # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
         self.db_config = db_config
+        self.matrix_directory = matrix_directory
         self.user_metadata = user_metadata
         self.engine = engine
 
@@ -90,7 +91,10 @@ class Architect(object):
             matrix_type
         )
         uuid = metta.generate_uuid(matrix_metadata)
-        matrix_filename = '{}.csv'.format(uuid)
+        matrix_filename = os.path.join(
+            self.matrix_directory,
+            '{}.csv'.format(uuid)
+        )
 
         if uuid not in completed_uuids:
             self.build_matrix(
@@ -168,7 +172,10 @@ class Architect(object):
         :return: name of csv containing labels
         :rtype: str
         """
-        csv_name = '{}.csv'.format(self.db_config['labels_table_name'])
+        csv_name = os.path.join(
+            self.matrix_directory,
+            '{}.csv'.format(self.db_config['labels_table_name'])
+        )
         as_of_time_strings = [str(as_of_time) for as_of_time in as_of_times]
         if matrix_type == 'train':
             labels_query = self.build_labels_query(
@@ -211,7 +218,10 @@ class Architect(object):
         # iterate! for each table, make query, write csv, save feature & file names
         features_csv_names = []
         for feature_table_name, feature_names in feature_dictionary.items():
-            csv_name = '{}.csv'.format(feature_table_name)
+            csv_name = os.path.join(
+                self.matrix_directory,
+                '{}.csv'.format(feature_table_name)
+            )
             features_query = self.build_outer_join_query(
                 as_of_times = as_of_times,
                 right_table_name = '{schema}.{table}'.format(


### PR DESCRIPTION
This change puts all the matrices in a particular directory instead of the run directory (triage will call this with {project_path}/matrices or whatever, i think). I thought of separating the temporary ones from the real ones, but I'm not sure it matters. That doesn't actually help us any, and we delete the temporary ones anyway. 