### PR TITLE
Allow Architect to skip building matrix if it exists [Resolves #45]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
   postgresql: "9.4"
 before_install:
 - sudo apt-get update
-- sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
+- sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran libhdf5-serial-dev
 install:
 - pip install -r requirements.txt
 script: py.test -vvv -s --cov=timechop

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ git+git://github.com/dssg/metta-data.git
 testing.postgresql
 SQLAlchemy
 psycopg2
+mock

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -11,6 +11,7 @@ import pandas as pd
 import os
 from sqlalchemy import create_engine
 from unittest import TestCase
+from unittest.mock import Mock
 
 
 # make some fake features data
@@ -635,3 +636,82 @@ class TestBuildMatrix(object):
                 with open(matrix_filename, 'r') as f:
                     reader = csv.reader(f)
                     assert(len([row for row in reader]) == 13)
+
+    def test_replace(self):
+        with testing.postgresql.Postgresql() as postgresql:
+            # create an engine and generate a table with fake feature data
+            engine = create_engine(postgresql.url())
+            create_features_and_labels_schemas(engine, features_tables, labels)
+
+            dates = [datetime.datetime(2016, 1, 1, 0, 0),
+                     datetime.datetime(2016, 2, 1, 0, 0),
+                     datetime.datetime(2016, 3, 1, 0, 0)]
+
+            with TemporaryDirectory() as temp_dir:
+                matrix_maker = Architect(
+                    beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
+                    label_names = ['booking'],
+                    label_types = ['binary'],
+                    db_config = db_config,
+                    matrix_directory = temp_dir,
+                    user_metadata = {},
+                    engine = engine,
+                    replace=False
+                )
+
+                matrix_dates = {
+                    'matrix_start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'matrix_end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'as_of_times': dates
+                }
+                feature_dictionary = {
+                    'features0': ['f1', 'f2'],
+                    'features1': ['f1', 'f2'],
+                }
+
+                uuid = '1234'
+                matrix_maker.build_matrix(
+                    as_of_times = dates,
+                    label_name = 'booking',
+                    label_type = 'binary',
+                    feature_dictionary = feature_dictionary,
+                    matrix_directory = temp_dir,
+                    matrix_metadata = {
+                        'matrix_id': 'hi',
+                        'label_name': 'booking',
+                        'end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                        'start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                        'prediction_window': '1d'
+                    },
+                    matrix_uuid = uuid,
+                    matrix_type = 'test'
+                )
+
+                matrix_filename = os.path.join(
+                    temp_dir,
+                    '{}.csv'.format(uuid)
+                )
+
+                with open(matrix_filename, 'r') as f:
+                    reader = csv.reader(f)
+                    assert(len([row for row in reader]) == 13)
+
+                # rerun
+                matrix_maker.make_entity_date_table = Mock()
+                matrix_maker.build_matrix(
+                    as_of_times = dates,
+                    label_name = 'booking',
+                    label_type = 'binary',
+                    feature_dictionary = feature_dictionary,
+                    matrix_directory = temp_dir,
+                    matrix_metadata = {
+                        'matrix_id': 'hi',
+                        'label_name': 'booking',
+                        'end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                        'start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                        'prediction_window': '1d'
+                    },
+                    matrix_uuid = uuid,
+                    matrix_type = 'test'
+                )
+                assert not matrix_maker.make_entity_date_table.called

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -11,7 +11,7 @@ import pandas as pd
 import os
 from sqlalchemy import create_engine
 from unittest import TestCase
-from unittest.mock import Mock
+from mock import Mock
 
 
 # make some fake features data

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -9,7 +9,7 @@ from . import utils
 class Architect(object):
 
     def __init__(self, beginning_of_time, label_names, label_types, db_config,
-                 matrix_directory, user_metadata, engine):
+                 matrix_directory, user_metadata, engine, replace=True):
         self.beginning_of_time = beginning_of_time # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
@@ -17,6 +17,7 @@ class Architect(object):
         self.matrix_directory = matrix_directory
         self.user_metadata = user_metadata
         self.engine = engine
+        self.replace = replace
 
     def _generate_build_task(
         self,
@@ -135,6 +136,10 @@ class Architect(object):
             matrix_directory,
             '{}.csv'.format(matrix_uuid)
         )
+        if not self.replace and os.path.exists(matrix_filename):
+            logging.info('Skipping %s because matrix already exists', matrix_filename)
+            return
+
         logging.info('Creating matrix %s > %s', matrix_metadata['matrix_id'], matrix_filename)
         # make the entity time table and query the labels and features tables
         logging.info('Making entity date table')


### PR DESCRIPTION
- Add replace kwarg to Architect constructor, which controls whether or not an existing matrix is overwritten