### PR TITLE
store matrix in temp file and remove

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -669,7 +669,13 @@ class TestBuildMatrix(object):
                     'features0': ['f1', 'f2'],
                     'features1': ['f1', 'f2'],
                 }
-
+                matrix_metadata = {
+                    'matrix_id': 'hi',
+                    'label_name': 'booking',
+                    'end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'prediction_window': '1d'
+                }
                 uuid = metta.generate_uuid(matrix_metadata)
                 matrix_maker.build_matrix(
                     as_of_times = dates,
@@ -677,13 +683,7 @@ class TestBuildMatrix(object):
                     label_type = 'binary',
                     feature_dictionary = feature_dictionary,
                     matrix_directory = temp_dir,
-                    matrix_metadata = {
-                        'matrix_id': 'hi',
-                        'label_name': 'booking',
-                        'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                        'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                        'prediction_window': '1d'
-                    },
+                    matrix_metadata = matrix_metadata,
                     matrix_uuid = uuid,
                     matrix_type = 'test'
                 )

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -572,7 +572,7 @@ class TestBuildMatrix(object):
 
                 matrix_filename = os.path.join(
                     temp_dir,
-                    '{}.csv'.format(uuid)
+                    'tmp_{}.csv'.format(uuid)
                 )
                 with open(matrix_filename, 'r') as f:
                     reader = csv.reader(f)
@@ -629,7 +629,7 @@ class TestBuildMatrix(object):
 
                 matrix_filename = os.path.join(
                     temp_dir,
-                    '{}.csv'.format(uuid)
+                    'tmp_{}.csv'.format(uuid)
                 )
 
                 with open(matrix_filename, 'r') as f:

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -11,6 +11,7 @@ import pandas as pd
 import os
 from sqlalchemy import create_engine
 from unittest import TestCase
+from metta import metta_io as metta
 
 
 # make some fake features data
@@ -551,28 +552,28 @@ class TestBuildMatrix(object):
                     'features0': ['f1', 'f2'],
                     'features1': ['f1', 'f2'],
                 }
-
-                uuid = '1234'
+                matrix_metadata = {
+                    'matrix_id': 'hi',
+                    'label_name': 'booking',
+                    'end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'prediction_window': '1d'
+                }
+                uuid = metta.generate_uuid(matrix_metadata)
                 matrix_maker.build_matrix(
                     as_of_times = dates,
                     label_name = 'booking',
                     label_type = 'binary',
                     feature_dictionary = feature_dictionary,
                     matrix_directory = temp_dir,
-                    matrix_metadata = {
-                        'matrix_id': 'hi',
-                        'label_name': 'booking',
-                        'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                        'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                        'prediction_window': '1d'
-                    },
+                    matrix_metadata = matrix_metadata,
                     matrix_uuid = uuid,
                     matrix_type = 'train'
                 )
 
                 matrix_filename = os.path.join(
                     temp_dir,
-                    'tmp_{}.csv'.format(uuid)
+                    '{}.csv'.format(uuid)
                 )
                 with open(matrix_filename, 'r') as f:
                     reader = csv.reader(f)
@@ -608,28 +609,28 @@ class TestBuildMatrix(object):
                     'features0': ['f1', 'f2'],
                     'features1': ['f1', 'f2'],
                 }
-
-                uuid = '1234'
+                matrix_metadata = {
+                    'matrix_id': 'hi',
+                    'label_name': 'booking',
+                    'end_time': datetime.datetime(2016, 3, 1, 0, 0),
+                    'start_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'prediction_window': '1d'
+                }
+                uuid = metta.generate_uuid(matrix_metadata)
                 matrix_maker.build_matrix(
                     as_of_times = dates,
                     label_name = 'booking',
                     label_type = 'binary',
                     feature_dictionary = feature_dictionary,
                     matrix_directory = temp_dir,
-                    matrix_metadata = {
-                        'matrix_id': 'hi',
-                        'label_name': 'booking',
-                        'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                        'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                        'prediction_window': '1d'
-                    },
+                    matrix_metadata = matrix_metadata,
                     matrix_uuid = uuid,
                     matrix_type = 'test'
                 )
-
+                print(os.listdir(temp_dir))
                 matrix_filename = os.path.join(
                     temp_dir,
-                    'tmp_{}.csv'.format(uuid)
+                    '{}.csv'.format(uuid)
                 )
 
                 with open(matrix_filename, 'r') as f:

--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -705,13 +705,7 @@ class TestBuildMatrix(object):
                     label_type = 'binary',
                     feature_dictionary = feature_dictionary,
                     matrix_directory = temp_dir,
-                    matrix_metadata = {
-                        'matrix_id': 'hi',
-                        'label_name': 'booking',
-                        'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                        'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                        'prediction_window': '1d'
-                    },
+                    matrix_metadata = matrix_metadata,
                     matrix_uuid = uuid,
                     matrix_type = 'test'
                 )

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -133,7 +133,7 @@ class Architect(object):
         """
         matrix_filename = os.path.join(
             matrix_directory,
-            '{}.csv'.format(matrix_uuid)
+            'tmp_{}.csv'.format(matrix_uuid)
         )
         logging.info('Creating matrix %s > %s', matrix_metadata['matrix_id'], matrix_filename)
         # make the entity time table and query the labels and features tables
@@ -181,13 +181,13 @@ class Architect(object):
         # clean up files and database before finishing
         for csv_name in features_csv_names:
             os.remove(csv_name)
+        os.remove(matrix_filename)
         self.engine.execute(
             'drop table "{}"."{}";'.format(
                 self.db_config['features_schema_name'],
                 entity_date_table_name
             )
         )
-
 
     def write_labels_data(self, as_of_times, label_name, label_type,
                           matrix_type, entity_date_table_name, matrix_uuid):

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -136,7 +136,12 @@ class Architect(object):
             matrix_directory,
             'tmp_{}.csv'.format(matrix_uuid)
         )
-        if not self.replace and os.path.exists(matrix_filename):
+        if not self.replace and os.path.exists(
+            os.path.join(
+                matrix_directory,
+                '{}.csv'.format(matrix_uuid)
+            )
+        ):
             logging.info('Skipping %s because matrix already exists', matrix_filename)
             return
 

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -132,9 +132,13 @@ class Architect(object):
         :return: none
         :rtype: none
         """
-        matrix_filename = os.path.join(
+        temp_matrix_filename = os.path.join(
             matrix_directory,
             'tmp_{}.csv'.format(matrix_uuid)
+        )
+        matrix_filename = os.path.join(
+            matrix_directory,
+            '{}.csv'.format(matrix_uuid)
         )
         if not self.replace and os.path.exists(
             os.path.join(
@@ -176,13 +180,13 @@ class Architect(object):
 
         # stitch together the csvs
         logging.info('Merging features data')
-        self.merge_feature_csvs(features_csv_names, matrix_filename)
+        self.merge_feature_csvs(features_csv_names, temp_matrix_filename)
 
         # store the matrix
         logging.info('Archiving matrix with metta')
         metta.archive_matrix(
             matrix_config=matrix_metadata,
-            df_matrix=matrix_filename,
+            df_matrix=temp_matrix_filename,
             overwrite=True,
             directory=self.matrix_directory,
             format='csv'
@@ -191,7 +195,7 @@ class Architect(object):
         # clean up files and database before finishing
         for csv_name in features_csv_names:
             os.remove(csv_name)
-        os.remove(matrix_filename)
+        os.remove(temp_matrix_filename)
         self.engine.execute(
             'drop table "{}"."{}";'.format(
                 self.db_config['features_schema_name'],


### PR DESCRIPTION
This PR allows timechop to work with the mv_csvs branch of metta-data. Matrices are saved to a temporary filepath before being archived with metta. This temporary file is removed during cleanup.