### PR TITLE
improve postgresql compatibility of interval parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 before_install:
 - sudo apt-get update
 - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
+- sudo apt-get install libhdf5-serial-dev
 install:
 - pip install -r requirements.txt
 script: py.test -vvv -s --cov=timechop

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,12 +46,12 @@ class test_convert_str_to_relativedelta(unittest.TestCase):
                 'subtraction_result': datetime.datetime(2015, 12, 31, 19, 0)
             },
             {
-                'interval': '10 minutes',
+                'interval': '10minutes',
                 'addition_result': datetime.datetime(2016, 1, 1, 0, 10),
                 'subtraction_result': datetime.datetime(2015, 12, 31, 23, 50)
             },
             {
-                'interval': '1 microsecond',
+                'interval': '1microsecond',
                 'addition_result': datetime.datetime(2016, 1, 1, 0, 0, 0, 1),
                 'subtraction_result': datetime.datetime(2015, 12, 31, 23, 59, 59, 999999)
             }
@@ -73,27 +73,30 @@ class test_convert_str_to_relativedelta(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 convert_str_to_relativedelta(delta_string)
-                assert len(w) == 1
+                for warning in w:
+                    print(warning.message)
+                assert len(w) >= 1
                 assert issubclass(w[-1].category, RuntimeWarning)
-                assert 'months' in str(w[-1].message)
+                assert 'minutes' in str(w[-1].message)
 
 
 class test_parse_delta_string(unittest.TestCase):
     def test_valid_input(self):
-        delta_strings = ['1 year', '2 months', '3 days', '3s', '2y']
+        delta_strings = ['1 year', '2 months', '3 days', '3s', '2y', '10m']
         expected_results = [
             ('year', 1),
             ('months', 2),
             ('days', 3),
             ('s', 3),
-            ('y', 2)
+            ('y', 2),
+            ('m', 10)
         ]        
         for index, delta_string in enumerate(delta_strings):
             result = parse_delta_string(delta_string)
             assert(result == expected_results[index])
 
     def test_invalid_input(self):
-        delta_strings = ['one year', '1yr', 'one_year', 'ay']
+        delta_strings = ['one year', 'one_year', 'ay']
         for delta_string in delta_strings:
             with self.assertRaises(ValueError):
                 parse_delta_string(delta_string)

--- a/timechop/utils.py
+++ b/timechop/utils.py
@@ -3,6 +3,7 @@ from dateutil.relativedelta import relativedelta
 import functools
 import operator
 import warnings
+import re
 
 def convert_str_to_relativedelta(delta_string):
     """ Given a string in a postgres interval format (e.g., '1 month'),
@@ -25,21 +26,21 @@ def convert_str_to_relativedelta(delta_string):
 
     if units in ['year', 'years', 'y', 'Y']:
         delta = relativedelta(years = value)
-    elif units in ['month', 'months', 'm', 'M']:
+    elif units in ['month', 'months']:
         delta = relativedelta(months = value)
-        if units in ['m', 'M']:
-            warnings.warn(
-                'Time delta units "{}" converted to months.'.format(units),
-                RuntimeWarning
-            )
     elif units in ['day', 'days', 'd', 'D']:
         delta = relativedelta(days = value)
     elif units in ['week', 'weeks', 'w', 'W']:
         delta = relativedelta(weeks = value)
     elif units in ['hour', 'hours', 'h', 'H']:
         delta = relativedelta(hours = value)
-    elif units in ['minute', 'minutes']:
+    elif units in ['minute', 'minutes', 'm', 'M']:
         delta = relativedelta(minutes = value)
+        if units in ['m', 'M']:
+            warnings.warn(
+                'Time delta units "{}" converted to minutes.'.format(units),
+                RuntimeWarning
+            )
     elif units in ['second', 'seconds', 's', 'S']:
         delta = relativedelta(seconds = value)
     elif units == 'microsecond' or units == 'microseconds':
@@ -60,19 +61,15 @@ def parse_delta_string(delta_string):
             raise ValueError('''
                 Could not parse value from time delta string: {}
             '''.format(delta_string))
-    elif len(delta_string) == 2:
-        units = delta_string[1]
+    else:
+        delta_parts = re.split('([a-zA-Z]*)', delta_string)
+        units = delta_parts[1]
         try:
-            value = int(delta_string[0])
+            value = int(delta_parts[0])
         except:
             raise ValueError('''
                 Could not parse value from time delta string: {}
             '''.format(delta_string))
-    else:
-        raise ValueError(
-            'Could not parse time delta string: {}'.format(delta_string)
-        )
-
     return(units, value)
 
 


### PR DESCRIPTION
Thus update makes a few changes to interval parsing:

- Consistent with PostgreSQL, 'm' and 'M' are now parsed as minutes rather than months
- Supports formats like `1day` and `30months` with full words but no spaces
- Fixes a bug where 2+ digits before the units would error if no space was used (e.g., `10d` would not parse previously)
