### PR TITLE
Update uuids

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -512,10 +512,13 @@ def test_generate_plans():
 
     updated_matrix_definitions, build_tasks = architect.generate_plans(matrix_set_definitions, feature_dicts)
     # test that it added uuids: we don't much care what they are
+    matrix_uuids = []
     for matrix_def in updated_matrix_definitions:
         assert isinstance(matrix_def['train_uuid'], str)
+        matrix_uuids.append(matrix_def['train_uuid'])
         for test_uuid in matrix_def['test_uuids']:
             assert isinstance(test_uuid, str)
+    assert len(set(matrix_uuids)) == 4
 
     # not going to assert anything on the keys (uuids), just get out the values
     build_tasks = build_tasks.values()

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -1,8 +1,11 @@
+import copy
+import os
 import csv
 import logging
-from metta import metta_io as metta
-import os
 import itertools
+
+from metta import metta_io as metta
+
 from . import utils
 
 
@@ -58,6 +61,7 @@ class Architect(object):
                 self.label_types,
                 feature_dictionaries
             ):
+                matrix_set_clone = copy.deepcopy(matrix_set)
                 # get a uuid
                 train_metadata = self._make_metadata(
                     train_matrix,
@@ -74,11 +78,10 @@ class Architect(object):
                         train_matrix,
                         feature_dictionary
                     )
-
-                matrix_set['train_uuid'] = train_uuid
+                matrix_set_clone['train_uuid'] = train_uuid
 
                 test_uuids = []
-                for test_matrix in matrix_set['test_matrices']:
+                for test_matrix in matrix_set_clone['test_matrices']:
                     test_metadata = self._make_metadata(
                         test_matrix,
                         feature_dictionary,
@@ -96,8 +99,8 @@ class Architect(object):
                         )
 
                     test_uuids.append(test_uuid)
-                matrix_set['test_uuids'] = test_uuids
-                updated_definitions.append(matrix_set)
+                matrix_set_clone['test_uuids'] = test_uuids
+                updated_definitions.append(matrix_set_clone)
 
         return updated_definitions, build_tasks
 

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import copy
 import os
 import csv
@@ -7,12 +6,7 @@ import itertools
 
 from metta import metta_io as metta
 
-from . import utils
-=======
-import itertools
-from metta import metta_io as metta
 from . import builders, utils
->>>>>>> edfd915faab7d8e5a9d9e9f5c2f5b78957fde91d
 
 
 class Architect(object):


### PR DESCRIPTION
This PR fixes a bug where Timechop would create the correct matrices but would send back a set of matrix definitions with repeated train/test uuids. 