### PR TITLE
Separate Train and Test Prediction Windows [resolves #26]

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -84,6 +84,45 @@ labels = [
     [3, '2016-03-01', '1 month', 'ems',     'binary', 0],
     [3, '2016-04-01', '1 month', 'ems',     'binary', 1],
     [3, '2016-05-01', '1 month', 'ems',     'binary', 0],
+    [0, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [0, '2016-03-01', '3 month', 'booking', 'binary', 0],
+    [0, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [0, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [0, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [0, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [0, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [0, '2016-04-01', '3 month', 'ems',     'binary', 0],
+    [0, '2016-05-01', '3 month', 'ems',     'binary', 0],
+    [1, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [1, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [1, '2016-03-01', '3 month', 'booking', 'binary', 0],
+    [1, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [1, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [1, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [1, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [1, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [1, '2016-04-01', '3 month', 'ems',     'binary', 0],
+    [1, '2016-05-01', '3 month', 'ems',     'binary', 0],
+    [2, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [2, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [2, '2016-03-01', '3 month', 'booking', 'binary', 1],
+    [2, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [2, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [2, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [2, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [2, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [2, '2016-04-01', '3 month', 'ems',     'binary', 0],
+    [2, '2016-05-01', '3 month', 'ems',     'binary', 1],
+    [3, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [3, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [3, '2016-03-01', '3 month', 'booking', 'binary', 1],
+    [3, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [3, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [3, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [3, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [3, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [3, '2016-04-01', '3 month', 'ems',     'binary', 1],
+    [3, '2016-05-01', '3 month', 'ems',     'binary', 0]
 ]
 
 label_name = 'booking'
@@ -155,10 +194,11 @@ def test_build_labels_query():
                 )
                 df = df.reset_index(drop = True)
                 query = architect.builder.build_labels_query(
-                    as_of_times = [date],
-                    label_type = label_type,
-                    label_name = label_name,
-                    final_column = ', label as {}'.format(label_name)
+                    as_of_times=[date],
+                    label_type=label_type,
+                    label_name=label_name,
+                    final_column=', label as {}'.format(label_name),
+                    prediction_window='1 month'
                 )
                 result = pd.read_sql(query, engine)
                 test = (result == df)
@@ -209,7 +249,14 @@ def test_make_entity_date_table():
              datetime.datetime(2016, 3, 1, 0, 0)]
 
     # make a dataframe of entity ids and dates to test against
-    ids_dates = create_entity_date_df(dates, labels, dates, 'booking', 'binary')
+    ids_dates = create_entity_date_df(
+        dates,
+        labels,
+        dates,
+        'booking',
+        'binary',
+        '1 month'
+    )
 
     with testing.postgresql.Postgresql() as postgresql:
         # create an engine and generate a table with fake feature data
@@ -231,12 +278,13 @@ def test_make_entity_date_table():
             )
             # call the function to test the creation of the table
             entity_date_table_name = architect.builder.make_entity_date_table(
-                as_of_times = dates,
-                label_type = 'binary',
-                label_name = 'booking',
-                feature_table_names = ['features0', 'features1'],
-                matrix_uuid = 'my_uuid',
-                matrix_type = 'train'
+                as_of_times=dates,
+                label_type='binary',
+                label_name='booking',
+                feature_table_names=['features0', 'features1'],
+                matrix_uuid='my_uuid',
+                matrix_type='train',
+                prediction_window='1 month'
             )
 
             # read in the table
@@ -264,7 +312,14 @@ def test_build_outer_join_query():
              datetime.datetime(2016, 2, 1, 0, 0)]
 
     # make dataframe for entity ids and dates
-    ids_dates = create_entity_date_df(dates, labels, dates, 'booking', 'binary')
+    ids_dates = create_entity_date_df(
+        dates,
+        labels,
+        dates,
+        'booking',
+        'binary',
+        '1 month'
+    )
 
     features = [['f1', 'f2'], ['f3', 'f4']]
     # make dataframes of features to test against
@@ -302,12 +357,13 @@ def test_build_outer_join_query():
 
             # make the entity-date table
             entity_date_table_name = architect.builder.make_entity_date_table(
-                as_of_times = dates,
-                label_type = 'binary',
-                label_name = 'booking',
-                feature_table_names = ['features0', 'features1'],
-                matrix_type = 'train',
-                matrix_uuid = 'my_uuid',
+                as_of_times=dates,
+                label_type='binary',
+                label_name='booking',
+                feature_table_names=['features0', 'features1'],
+                matrix_type='train',
+                matrix_uuid='my_uuid',
+                prediction_window='1 month'
             )
 
             # get the queries and test them
@@ -568,7 +624,7 @@ class TestBuildMatrix(object):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'prediction_window': '1d'
+                    'prediction_window': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
@@ -625,7 +681,7 @@ class TestBuildMatrix(object):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'prediction_window': '1d'
+                    'prediction_window': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
@@ -684,7 +740,7 @@ class TestBuildMatrix(object):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'prediction_window': '1d'
+                    'prediction_window': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(

--- a/tests/test_timechop.py
+++ b/tests/test_timechop.py
@@ -1,4 +1,4 @@
-from timechop.timechop import Inspections
+from timechop.timechop import Timechop
 import datetime
 from unittest import TestCase
 import warnings
@@ -9,32 +9,44 @@ class test_calculate_update_times(TestCase):
             datetime.datetime(2011, 1, 1, 0, 0),
             datetime.datetime(2012, 1, 1, 0, 0)
         ]
-        chopper = Inspections(
-            beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
-            modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-            modeling_end_time = datetime.datetime(2013, 1, 1, 0, 0),
-            update_window = '1 year',
-            look_back_durations = ['1 year'],
-            train_example_frequency = '1 day',
-            test_example_frequency = '1 day',
-            test_durations = ['1 month']
+        chopper = Timechop(
+            beginning_of_time=datetime.datetime(1990, 1, 1, 0, 0),
+            modeling_start_time=datetime.datetime(2010, 1, 1, 0, 0),
+            modeling_end_time=datetime.datetime(2013, 1, 1, 0, 0),
+            update_window='1 year',
+            train_example_frequency='1 day',
+            test_example_frequency='1 day',
+            train_durations=['1 year'],
+            test_durations=['1 month'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
-        result = chopper.calculate_matrix_end_times('1 year')
+        result = chopper.calculate_matrix_end_times(
+            train_duration='1 year',
+            train_prediction_window='1 day',
+            test_prediction_window='3 months'
+        )
         assert(result == expected_result)
 
     def test_invalid_input(self):
-        chopper = Inspections(
+        chopper = Timechop(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2011, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2011, 2, 1, 0, 0),
             update_window = '5 months',
-            look_back_durations = ['1 year'],
             train_example_frequency = '1 day',
             test_example_frequency = '1 day',
-            test_durations = ['1 month']
+            train_durations = ['1 year'],
+            test_durations = ['1 month'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
         with self.assertRaises(ValueError):
-            chopper.calculate_matrix_end_times('1 year')
+            chopper.calculate_matrix_end_times(
+                train_duration='1 year',
+                train_prediction_window='1 day',
+                test_prediction_window='3 months'
+            )
 
 
 def test_calculate_as_of_times_one_day_freq():
@@ -50,15 +62,17 @@ def test_calculate_as_of_times_one_day_freq():
         datetime.datetime(2011, 1, 9, 0, 0),
         datetime.datetime(2011, 1, 10, 0, 0),
     ]
-    chopper = Inspections(
+    chopper = Timechop(
         beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
         modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
         modeling_end_time = datetime.datetime(2012, 1, 1, 0, 0),
         update_window = '1 year',
-        look_back_durations = ['10 days', '1 year'],
         train_example_frequency = '1 days',
         test_example_frequency = '7 days',
-        test_durations = ['1 month']
+        train_durations = ['10 days', '1 year'],
+        test_durations = ['1 month'],
+        train_prediction_windows=['1 day'],
+        test_prediction_windows=['3 months']
     )
     result = chopper.calculate_as_of_times(
         matrix_start_time = datetime.datetime(2011, 1, 1, 0, 0),
@@ -75,15 +89,17 @@ def test_calculate_as_of_times_three_day_freq():
         datetime.datetime(2011, 1, 7, 0, 0),
         datetime.datetime(2011, 1, 10, 0, 0),
     ]
-    chopper = Inspections(
+    chopper = Timechop(
         beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
         modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
         modeling_end_time = datetime.datetime(2012, 1, 1, 0, 0),
         update_window = '1 year',
-        look_back_durations = ['10 days', '1 year'],
         train_example_frequency = '1 days',
         test_example_frequency = '7 days',
-        test_durations = ['1 month']
+        train_durations = ['10 days', '1 year'],
+        test_durations = ['1 month'],
+        train_prediction_windows=['1 day'],
+        test_prediction_windows=['3 months']
     )
     result = chopper.calculate_as_of_times(
         matrix_start_time = datetime.datetime(2011, 1, 1, 0, 0),
@@ -108,7 +124,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 3, 0, 0),
                     datetime.datetime(2010, 1, 4, 0, 0),
                     datetime.datetime(2010, 1, 5, 0, 0)
-                ]
+                ],
+                'prediction_window': '1 day'
             },
             'test_matrices': [{
                 'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -116,22 +133,27 @@ class test_generate_matrix_definition(TestCase):
                 'as_of_times': [
                     datetime.datetime(2010, 1, 6, 0, 0),
                     datetime.datetime(2010, 1, 9, 0, 0),
-                ]
+                ],
+                'prediction_window': '3 months'
             }]
         }
-        chopper = Inspections(
+        chopper = Timechop(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 11, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['5 days'],
             train_example_frequency = '1 days',
             test_example_frequency = '3 days',
-            test_durations = ['5 days']
+            train_durations = ['5 days'],
+            test_durations = ['5 days'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
         result = chopper.generate_matrix_definition(
             train_matrix_end_time = datetime.datetime(2010, 1, 6, 0, 0),
-            look_back_duration = '5 days'
+            train_duration = '5 days',
+            train_prediction_window='1 day',
+            test_prediction_window='3 months'
         )
         assert result == expected_result
 
@@ -149,7 +171,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 3, 0, 0),
                     datetime.datetime(2010, 1, 4, 0, 0),
                     datetime.datetime(2010, 1, 5, 0, 0)
-                ]
+                ],
+            'prediction_window': '1 day'
             },
             'test_matrices': [
                 {
@@ -157,7 +180,8 @@ class test_generate_matrix_definition(TestCase):
                     'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 },
                 {
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -165,7 +189,8 @@ class test_generate_matrix_definition(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 13, 0, 0),
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 }
             ]
         }
@@ -173,19 +198,23 @@ class test_generate_matrix_definition(TestCase):
         # test matrices in a list and (b) 10 and 15 day durations produce
         # redundanct test matrices (because 15 days after training period is 
         # beyond the end of the modeling time), only one of which is returned
-        chopper = Inspections(
+        chopper = Timechop(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['10 days'],
             train_example_frequency = '1 days',
             test_example_frequency = '7 days',
-            test_durations = ['5 days', '10 days', '15 days']
+            train_durations = ['10 days'],
+            test_durations = ['5 days', '10 days', '15 days'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
         result = chopper.generate_matrix_definition(
             train_matrix_end_time = datetime.datetime(2010, 1, 6, 0, 0),
-            look_back_duration = '10 days'
+            train_duration = '10 days',
+            train_prediction_window='1 day',
+            test_prediction_window='3 months'
         )
         assert result == expected_result
 
@@ -206,7 +235,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 3, 0, 0),
                         datetime.datetime(2010, 1, 4, 0, 0),
                         datetime.datetime(2010, 1, 5, 0, 0)
-                    ]
+                    ],
+                'prediction_window': '1 day'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -214,7 +244,8 @@ class test_chop_time(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 }]
             },
             {
@@ -230,7 +261,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
                         datetime.datetime(2010, 1, 10, 0, 0)
-                    ]
+                    ],
+                'prediction_window': '1 day'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
@@ -238,19 +270,22 @@ class test_chop_time(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 11, 0, 0),
                         datetime.datetime(2010, 1, 14, 0, 0)
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 }]
             }
         ]
-        chopper = Inspections(
+        chopper = Timechop(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['5 days'],
             train_example_frequency = '1 days',
             test_example_frequency = '3 days',
-            test_durations = ['5 days']
+            train_durations = ['5 days'],
+            test_durations = ['5 days'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
         result = chopper.chop_time()
         assert(result == expected_result)
@@ -270,14 +305,16 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 3, 0, 0),
                         datetime.datetime(2010, 1, 4, 0, 0),
                         datetime.datetime(2010, 1, 5, 0, 0)
-                    ]
+                    ],
+                    'prediction_window': '1 day'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
                     'matrix_end_time': datetime.datetime(2010, 1, 11, 0, 0),
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 }]
             },
             {
@@ -295,27 +332,31 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
                         datetime.datetime(2010, 1, 10, 0, 0)
-                    ]
+                    ],
+                    'prediction_window': '1 day'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
                     'matrix_end_time': datetime.datetime(2010, 1, 16, 0, 0),
                     'as_of_times': [
                         datetime.datetime(2010, 1, 11, 0, 0),
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 }]
             }
         ]
 
-        chopper = Inspections(
+        chopper = Timechop(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '5 days',
-            look_back_durations = ['7 days'],
             train_example_frequency = '1 days',
             test_example_frequency = '7 days',
-            test_durations = ['5 days']
+            train_durations = ['7 days'],
+            test_durations = ['5 days'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
         
         with warnings.catch_warnings(record = True) as w:
@@ -339,7 +380,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 5, 0, 0),
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 7, 0, 0)
-                    ]
+                    ],
+                    'prediction_window': '1 day'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 8, 0, 0),
@@ -347,20 +389,23 @@ class test_chop_time(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 12, 0, 0)
-                    ]
+                    ],
+                    'prediction_window': '3 months'
                 }]
             }
         ]
 
-        chopper = Inspections(
+        chopper = Timechop(
             beginning_of_time = datetime.datetime(1990, 1, 1, 0, 0),
             modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
             modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
             update_window = '8 days',
-            look_back_durations = ['5 days'],
             train_example_frequency = '1 days',
             test_example_frequency = '4 days',
-            test_durations = ['5 days']
+            train_durations = ['5 days'],
+            test_durations = ['5 days'],
+            train_prediction_windows=['1 day'],
+            test_prediction_windows=['3 months']
         )
         
         with warnings.catch_warnings(record = True) as w:
@@ -375,13 +420,15 @@ class test_chop_time(TestCase):
 class test__init__(TestCase):
     def test_bad_beginning_of_time(self):
         with self.assertRaises(ValueError):
-            chopper = Inspections(
+            chopper = Timechop(
                 beginning_of_time = datetime.datetime(2011, 1, 1, 0, 0),
                 modeling_start_time = datetime.datetime(2010, 1, 1, 0, 0),
                 modeling_end_time = datetime.datetime(2010, 1, 16, 0, 0),
                 update_window = '6 days',
-                look_back_durations = ['5 days'],
                 train_example_frequency = '1 days',
                 test_example_frequency = '7 days',
-                test_durations = ['5 days']
+                train_durations = ['5 days'],
+                test_durations = ['5 days'],
+                train_prediction_windows=['1 day'],
+                test_prediction_windows=['3 months']
             )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,8 +58,14 @@ def create_features_table(table_number, table, engine):
             row
         )
 
-def create_entity_date_df(dates, labels, as_of_dates, label_name,
-                          label_type):
+def create_entity_date_df(
+    dates,
+    labels,
+    as_of_dates,
+    label_name,
+    label_type,
+    prediction_window
+):
     """ This function makes a pandas DataFrame that mimics the entity-date table
     for testing against.
     """
@@ -75,6 +81,7 @@ def create_entity_date_df(dates, labels, as_of_dates, label_name,
     dates = [date.date() for date in dates]
     labels_table = labels_table[labels_table['label_name'] == label_name]
     labels_table = labels_table[labels_table['label_type'] == label_type]
+    labels_table = labels_table[labels_table['prediction_window'] == prediction_window]
     ids_dates = labels_table[['entity_id', 'as_of_date']]
     ids_dates = ids_dates.sort_values(['entity_id', 'as_of_date'])
     ids_dates['as_of_date'] = [datetime.datetime.strptime(

--- a/timechop/timechop.py
+++ b/timechop/timechop.py
@@ -2,39 +2,66 @@ from . import utils
 from dateutil.relativedelta import relativedelta
 import warnings
 import logging
+import itertools
 
-class Inspections(object):
-    def __init__(self, beginning_of_time, modeling_start_time,
-                 modeling_end_time, update_window, look_back_durations,
-                 train_example_frequency, test_example_frequency,
-                 test_durations):
+class Timechop(object):
+    def __init__(
+        self,
+        beginning_of_time,
+        modeling_start_time,
+        modeling_end_time,
+        update_window,
+        train_example_frequency,
+        test_example_frequency,
+        train_durations,
+        test_durations,
+        train_prediction_windows,
+        test_prediction_windows
+    ):
         self.beginning_of_time = beginning_of_time # earliest date included in features
         self.modeling_start_time = modeling_start_time # earliest date in any model
         self.modeling_end_time = modeling_end_time # all dates in any model are < this date
         self.update_window = update_window # how frequently to retrain models
-        self.look_back_durations = look_back_durations # keep creating rows in train matrix for this duration
         self.train_example_frequency = train_example_frequency # time between rows for same entity in train matrix
         self.test_example_frequency = test_example_frequency # time between rows for same entity in test matrix
+        self.train_durations = train_durations # keep creating rows in train matrix for this duration
         self.test_durations = test_durations # keep creating rows in test matrix for this duration
+        self.train_prediction_windows = train_prediction_windows # how much time is included in a label in the train matrix
+        self.test_prediction_windows = test_prediction_windows # how much time is included in a label in the test matrix
         if beginning_of_time > modeling_start_time:
             raise ValueError('Beginning of time is later than modeling start time.')
 
     def chop_time(self):
         matrix_set_definitions = []
-        for look_back_duration in self.look_back_durations:
-            matrix_end_times = self.calculate_matrix_end_times(look_back_duration)
+        for train_duration, train_prediction_window, test_prediction_window in itertools.product(
+                self.train_durations,
+                self.train_prediction_windows,
+                self.test_prediction_windows
+            ):
+            matrix_end_times = self.calculate_matrix_end_times(
+                train_duration,
+                train_prediction_window,
+                test_prediction_window
+            )
             for matrix_end_time in matrix_end_times:
                 matrix_set_definitions.append(
                     self.generate_matrix_definition(
                         matrix_end_time,
-                        look_back_duration
+                        train_duration,
+                        train_prediction_window,
+                        test_prediction_window
                     )
                 )
         return(matrix_set_definitions)
 
-    def calculate_matrix_end_times(self, look_back_duration):
+    def calculate_matrix_end_times(
+            self,
+            train_duration,
+            train_prediction_window,
+            test_prediction_window
+        ):
         update_delta = utils.convert_str_to_relativedelta(self.update_window)
-        look_back_delta = utils.convert_str_to_relativedelta(look_back_duration)
+        train_delta = utils.convert_str_to_relativedelta(train_duration)
         matrix_end_times = []
         matrix_end_time = self.modeling_end_time - update_delta
         
@@ -73,9 +100,15 @@ class Inspections(object):
             as_of_time += example_delta
         return(as_of_times)
 
-    def generate_matrix_definition(self, train_matrix_end_time, look_back_duration):
-        look_back_delta = utils.convert_str_to_relativedelta(look_back_duration)
-        train_matrix_start_time = train_matrix_end_time - look_back_delta
+    def generate_matrix_definition(
+            self,
+            train_matrix_end_time,
+            train_duration,
+            train_prediction_window,
+            test_prediction_window
+        ):
+        train_delta = utils.convert_str_to_relativedelta(train_duration)
+        train_matrix_start_time = train_matrix_end_time - train_delta
         if train_matrix_start_time < self.modeling_start_time:
             train_matrix_start_time = self.modeling_start_time
         print('train end: {}'.format(train_matrix_end_time))
@@ -85,7 +118,10 @@ class Inspections(object):
             train_matrix_end_time,
             self.train_example_frequency
         )
-        test_matrices = self.define_test_matrices(train_matrix_end_time)
+        test_matrices = self.define_test_matrices(
+            train_matrix_end_time,
+            test_prediction_window
+        )
             
         matrix_definition = {
             'beginning_of_time': self.beginning_of_time,
@@ -94,13 +130,18 @@ class Inspections(object):
             'train_matrix': {
                 'matrix_start_time': train_matrix_start_time,
                 'matrix_end_time': train_matrix_end_time,
-                'as_of_times': train_as_of_times
+                'as_of_times': train_as_of_times,
+                'prediction_window': train_prediction_window
             },
             'test_matrices': test_matrices
         }
         return(matrix_definition)
 
-    def define_test_matrices(self, train_matrix_end_time):
+    def define_test_matrices(
+        self,
+        train_matrix_end_time,
+        test_prediction_window
+    ):
         test_definitions = []
         test_end_times = []
         for test_duration in self.test_durations:
@@ -117,7 +158,8 @@ class Inspections(object):
                 test_definition = {
                     'matrix_start_time': train_matrix_end_time,
                     'matrix_end_time': test_end_time,
-                    'as_of_times': test_as_of_times
+                    'as_of_times': test_as_of_times,
+                    'prediction_window': test_prediction_window
                 }
                 test_definitions.append(test_definition)
                 test_end_times.append(test_end_time)


### PR DESCRIPTION
If merged, this commit will

- Rename Inspections class to Timechop
- Require train_prediction_windows and test_prediction_windows parameters for Timechop.chop_time()
- Build matrix definitions for all combinations of train_prediction_windows and test_prediction_windows passed
- Filter labels by prediction window when building matrices
- Rename `look_back_duration` to `train_duration`