### PR TITLE
Rename Metadata Keys

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -153,7 +153,7 @@ def test_build_labels_query():
         columns = [
             'entity_id',
             'as_of_date',
-            'prediction_window',
+            'label_window',
             'label_name',
             'label_type',
             'label'
@@ -181,7 +181,7 @@ def test_build_labels_query():
                 date = date.date()
                 df = labels_df[labels_df['label_name'] == label_name]
                 df = df[labels_df['label_type'] == label_type]
-                df = df[labels_df['prediction_window'] == '1 month']
+                df = df[labels_df['label_window'] == '1 month']
                 print(date)
                 df = df[labels_df['as_of_date'] == date]
                 df = df[['entity_id', 'as_of_date', 'label']]
@@ -198,7 +198,7 @@ def test_build_labels_query():
                     label_type=label_type,
                     label_name=label_name,
                     final_column=', label as {}'.format(label_name),
-                    prediction_window='1 month'
+                    label_window='1 month'
                 )
                 result = pd.read_sql(query, engine)
                 test = (result == df)
@@ -284,7 +284,7 @@ def test_make_entity_date_table():
                 feature_table_names=['features0', 'features1'],
                 matrix_uuid='my_uuid',
                 matrix_type='train',
-                prediction_window='1 month'
+                label_window='1 month'
             )
 
             # read in the table
@@ -363,7 +363,7 @@ def test_build_outer_join_query():
                 feature_table_names=['features0', 'features1'],
                 matrix_type='train',
                 matrix_uuid='my_uuid',
-                prediction_window='1 month'
+                label_window='1 month'
             )
 
             # get the queries and test them
@@ -623,8 +623,8 @@ class TestBuildMatrix(object):
                     'matrix_id': 'hi',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'prediction_window': '1 month'
+                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'label_window': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
@@ -680,8 +680,8 @@ class TestBuildMatrix(object):
                     'matrix_id': 'hi',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'prediction_window': '1 month'
+                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'label_window': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
@@ -739,8 +739,8 @@ class TestBuildMatrix(object):
                     'matrix_id': 'hi',
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'start_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'prediction_window': '1 month'
+                    'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
+                    'label_window': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(

--- a/tests/test_timechop.py
+++ b/tests/test_timechop.py
@@ -18,13 +18,13 @@ class test_calculate_update_times(TestCase):
             test_example_frequency='1 day',
             train_durations=['1 year'],
             test_durations=['1 month'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         result = chopper.calculate_matrix_end_times(
             train_duration='1 year',
-            train_prediction_window='1 day',
-            test_prediction_window='3 months'
+            train_label_window='1 day',
+            test_label_window='3 months'
         )
         assert(result == expected_result)
 
@@ -38,14 +38,14 @@ class test_calculate_update_times(TestCase):
             test_example_frequency = '1 day',
             train_durations = ['1 year'],
             test_durations = ['1 month'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         with self.assertRaises(ValueError):
             chopper.calculate_matrix_end_times(
                 train_duration='1 year',
-                train_prediction_window='1 day',
-                test_prediction_window='3 months'
+                train_label_window='1 day',
+                test_label_window='3 months'
             )
 
 
@@ -71,8 +71,8 @@ def test_calculate_as_of_times_one_day_freq():
         test_example_frequency = '7 days',
         train_durations = ['10 days', '1 year'],
         test_durations = ['1 month'],
-        train_prediction_windows=['1 day'],
-        test_prediction_windows=['3 months']
+        train_label_windows=['1 day'],
+        test_label_windows=['3 months']
     )
     result = chopper.calculate_as_of_times(
         matrix_start_time = datetime.datetime(2011, 1, 1, 0, 0),
@@ -98,8 +98,8 @@ def test_calculate_as_of_times_three_day_freq():
         test_example_frequency = '7 days',
         train_durations = ['10 days', '1 year'],
         test_durations = ['1 month'],
-        train_prediction_windows=['1 day'],
-        test_prediction_windows=['3 months']
+        train_label_windows=['1 day'],
+        test_label_windows=['3 months']
     )
     result = chopper.calculate_as_of_times(
         matrix_start_time = datetime.datetime(2011, 1, 1, 0, 0),
@@ -125,7 +125,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 4, 0, 0),
                     datetime.datetime(2010, 1, 5, 0, 0)
                 ],
-                'prediction_window': '1 day'
+                'label_window': '1 day',
+                'example_frequency': '1 days'
             },
             'test_matrices': [{
                 'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -134,7 +135,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 6, 0, 0),
                     datetime.datetime(2010, 1, 9, 0, 0),
                 ],
-                'prediction_window': '3 months'
+                'label_window': '3 months',
+                'example_frequency': '3 days'
             }]
         }
         chopper = Timechop(
@@ -146,14 +148,14 @@ class test_generate_matrix_definition(TestCase):
             test_example_frequency = '3 days',
             train_durations = ['5 days'],
             test_durations = ['5 days'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         result = chopper.generate_matrix_definition(
             train_matrix_end_time = datetime.datetime(2010, 1, 6, 0, 0),
             train_duration = '5 days',
-            train_prediction_window='1 day',
-            test_prediction_window='3 months'
+            train_label_window='1 day',
+            test_label_window='3 months'
         )
         assert result == expected_result
 
@@ -172,7 +174,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 4, 0, 0),
                     datetime.datetime(2010, 1, 5, 0, 0)
                 ],
-            'prediction_window': '1 day'
+                'label_window': '1 day',
+                'example_frequency': '1 days'
             },
             'test_matrices': [
                 {
@@ -181,7 +184,8 @@ class test_generate_matrix_definition(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '7 days'
                 },
                 {
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -190,7 +194,8 @@ class test_generate_matrix_definition(TestCase):
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 13, 0, 0),
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '7 days'
                 }
             ]
         }
@@ -207,14 +212,14 @@ class test_generate_matrix_definition(TestCase):
             test_example_frequency = '7 days',
             train_durations = ['10 days'],
             test_durations = ['5 days', '10 days', '15 days'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         result = chopper.generate_matrix_definition(
             train_matrix_end_time = datetime.datetime(2010, 1, 6, 0, 0),
             train_duration = '10 days',
-            train_prediction_window='1 day',
-            test_prediction_window='3 months'
+            train_label_window='1 day',
+            test_label_window='3 months'
         )
         assert result == expected_result
 
@@ -236,7 +241,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 4, 0, 0),
                         datetime.datetime(2010, 1, 5, 0, 0)
                     ],
-                'prediction_window': '1 day'
+                    'label_window': '1 day',
+                    'example_frequency': '1 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -245,7 +251,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 9, 0, 0),
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '3 days'
                 }]
             },
             {
@@ -262,7 +269,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 9, 0, 0),
                         datetime.datetime(2010, 1, 10, 0, 0)
                     ],
-                'prediction_window': '1 day'
+                    'label_window': '1 day',
+                    'example_frequency': '1 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
@@ -271,7 +279,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 11, 0, 0),
                         datetime.datetime(2010, 1, 14, 0, 0)
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '3 days'
                 }]
             }
         ]
@@ -284,8 +293,8 @@ class test_chop_time(TestCase):
             test_example_frequency = '3 days',
             train_durations = ['5 days'],
             test_durations = ['5 days'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         result = chopper.chop_time()
         assert(result == expected_result)
@@ -306,7 +315,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 4, 0, 0),
                         datetime.datetime(2010, 1, 5, 0, 0)
                     ],
-                    'prediction_window': '1 day'
+                    'label_window': '1 day',
+                    'example_frequency': '1 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -314,7 +324,8 @@ class test_chop_time(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 6, 0, 0),
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '7 days'
                 }]
             },
             {
@@ -333,7 +344,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 9, 0, 0),
                         datetime.datetime(2010, 1, 10, 0, 0)
                     ],
-                    'prediction_window': '1 day'
+                    'label_window': '1 day',
+                    'example_frequency': '1 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
@@ -341,7 +353,8 @@ class test_chop_time(TestCase):
                     'as_of_times': [
                         datetime.datetime(2010, 1, 11, 0, 0),
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '7 days'
                 }]
             }
         ]
@@ -355,8 +368,8 @@ class test_chop_time(TestCase):
             test_example_frequency = '7 days',
             train_durations = ['7 days'],
             test_durations = ['5 days'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         
         with warnings.catch_warnings(record = True) as w:
@@ -381,7 +394,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 6, 0, 0),
                         datetime.datetime(2010, 1, 7, 0, 0)
                     ],
-                    'prediction_window': '1 day'
+                    'label_window': '1 day',
+                    'example_frequency': '1 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 8, 0, 0),
@@ -390,7 +404,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 8, 0, 0),
                         datetime.datetime(2010, 1, 12, 0, 0)
                     ],
-                    'prediction_window': '3 months'
+                    'label_window': '3 months',
+                    'example_frequency': '4 days'
                 }]
             }
         ]
@@ -404,8 +419,8 @@ class test_chop_time(TestCase):
             test_example_frequency = '4 days',
             train_durations = ['5 days'],
             test_durations = ['5 days'],
-            train_prediction_windows=['1 day'],
-            test_prediction_windows=['3 months']
+            train_label_windows=['1 day'],
+            test_label_windows=['3 months']
         )
         
         with warnings.catch_warnings(record = True) as w:
@@ -429,6 +444,6 @@ class test__init__(TestCase):
                 test_example_frequency = '7 days',
                 train_durations = ['5 days'],
                 test_durations = ['5 days'],
-                train_prediction_windows=['1 day'],
-                test_prediction_windows=['3 months']
+                train_label_windows=['1 day'],
+                test_label_windows=['3 months']
             )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ def create_features_and_labels_schemas(engine, features_tables, labels):
             create table labels.labels (
                 entity_id int,
                 as_of_date date,
-                prediction_window interval,
+                label_window interval,
                 label_name char(30),
                 label_type char(30),
                 label int
@@ -64,7 +64,7 @@ def create_entity_date_df(
     as_of_dates,
     label_name,
     label_type,
-    prediction_window
+    label_window
 ):
     """ This function makes a pandas DataFrame that mimics the entity-date table
     for testing against.
@@ -73,7 +73,7 @@ def create_entity_date_df(
     labels_table = pd.DataFrame(labels, columns = [
         'entity_id',
         'as_of_date',
-        'prediction_window',
+        'label_window',
         'label_name',
         'label_type',
         'label'
@@ -81,7 +81,7 @@ def create_entity_date_df(
     dates = [date.date() for date in dates]
     labels_table = labels_table[labels_table['label_name'] == label_name]
     labels_table = labels_table[labels_table['label_type'] == label_type]
-    labels_table = labels_table[labels_table['prediction_window'] == prediction_window]
+    labels_table = labels_table[labels_table['label_window'] == label_window]
     ids_dates = labels_table[['entity_id', 'as_of_date']]
     ids_dates = ids_dates.sort_values(['entity_id', 'as_of_date'])
     ids_dates['as_of_date'] = [datetime.datetime.strptime(

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -76,7 +76,7 @@ class Architect(object):
         matrix_metadata = {
 
             # temporal information
-            'start_time': self.beginning_of_time,
+            'beginning_of_time': self.beginning_of_time,
             'end_time': matrix_definition['matrix_end_time'],
 
             # columns

--- a/timechop/builders.py
+++ b/timechop/builders.py
@@ -44,7 +44,7 @@ class BuilderBase(object):
             final_column,
             label_name,
             label_type,
-            prediction_window
+            label_window
         ):
         """ Given a table, schema, and list of dates, write a query to get the
         list of valid as_of_date-entity pairs, and, if requested, the labels.
@@ -67,7 +67,7 @@ class BuilderBase(object):
             WHERE as_of_date IN (SELECT (UNNEST (ARRAY{times}::timestamp[]))) AND
                   label_name = '{l_name}' AND
                   label_type = '{l_type}' AND
-                  prediction_window = '{window}'
+                  label_window = '{window}'
             ORDER BY entity_id,
                      as_of_date
         """.format(
@@ -77,7 +77,7 @@ class BuilderBase(object):
             times = as_of_time_strings,
             l_name = label_name,
             l_type = label_type,
-            window = prediction_window
+            window = label_window
         )
         return(query)
 
@@ -141,7 +141,7 @@ class BuilderBase(object):
         feature_table_names,
         matrix_type,
         matrix_uuid,
-        prediction_window
+        label_window
     ):
         """ Make a table containing the entity_ids and as_of_dates required for
         the current matrix.
@@ -160,7 +160,7 @@ class BuilderBase(object):
                 final_column='',
                 label_name=label_name,
                 label_type=label_type,
-                prediction_window=prediction_window
+                label_window=label_window
             )
         elif matrix_type == 'test':
             indices_query = self.get_all_valid_entity_date_combos(
@@ -259,7 +259,7 @@ class CSVBuilder(BuilderBase):
             feature_dictionary.keys(),
             matrix_type,
             matrix_uuid,
-            matrix_metadata['prediction_window']
+            matrix_metadata['label_window']
         )
         try:
             logging.info('Writing feature group data')
@@ -278,7 +278,7 @@ class CSVBuilder(BuilderBase):
                     matrix_type,
                     entity_date_table_name,
                     matrix_uuid,
-                    matrix_metadata['prediction_window']
+                    matrix_metadata['label_window']
                 )
                 features_csv_names.insert(0, labels_csv_name)
 
@@ -323,7 +323,7 @@ class CSVBuilder(BuilderBase):
         matrix_type,
         entity_date_table_name,
         matrix_uuid,
-        prediction_window
+        label_window
     ):
         """ Query the labels table and write the data to disk in csv format.
         
@@ -341,7 +341,7 @@ class CSVBuilder(BuilderBase):
                 final_column=', label as {}'.format(label_name),
                 label_name=label_name,
                 label_type=label_type,
-                prediction_window=prediction_window
+                label_window=label_window
             )
         elif matrix_type == 'test':
             labels_query=self.build_outer_join_query(
@@ -358,11 +358,11 @@ class CSVBuilder(BuilderBase):
                 additional_conditions='''AND
                     r.label_name = '{name}' AND
                     r.label_type = '{type}' AND
-                    r.prediction_window = '{window}'
+                    r.label_window = '{window}'
                 '''.format(
                     name=label_name,
                     type=label_type,
-                    window=prediction_window
+                    window=label_window
                 )
             )
         else:


### PR DESCRIPTION
If merged, this commit will:

- rename prediction windows to label windows
- rename look_back_duration to train_duration
- add example frequencies as metadata keys