### PR TITLE
add train duration to train matrix metadata

### DIFF
--- a/tests/test_timechop.py
+++ b/tests/test_timechop.py
@@ -126,7 +126,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 5, 0, 0)
                 ],
                 'label_window': '1 day',
-                'example_frequency': '1 days'
+                'example_frequency': '1 days',
+                'train_duration': '5 days'
             },
             'test_matrices': [{
                 'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -175,7 +176,8 @@ class test_generate_matrix_definition(TestCase):
                     datetime.datetime(2010, 1, 5, 0, 0)
                 ],
                 'label_window': '1 day',
-                'example_frequency': '1 days'
+                'example_frequency': '1 days',
+                'train_duration': '10 days'
             },
             'test_matrices': [
                 {
@@ -242,7 +244,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 5, 0, 0)
                     ],
                     'label_window': '1 day',
-                    'example_frequency': '1 days'
+                    'example_frequency': '1 days',
+                    'train_duration': '5 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -270,7 +273,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 10, 0, 0)
                     ],
                     'label_window': '1 day',
-                    'example_frequency': '1 days'
+                    'example_frequency': '1 days',
+                    'train_duration': '5 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
@@ -316,7 +320,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 5, 0, 0)
                     ],
                     'label_window': '1 day',
-                    'example_frequency': '1 days'
+                    'example_frequency': '1 days',
+                    'train_duration': '7 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 6, 0, 0),
@@ -345,7 +350,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 10, 0, 0)
                     ],
                     'label_window': '1 day',
-                    'example_frequency': '1 days'
+                    'example_frequency': '1 days',
+                    'train_duration': '7 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 11, 0, 0),
@@ -395,7 +401,8 @@ class test_chop_time(TestCase):
                         datetime.datetime(2010, 1, 7, 0, 0)
                     ],
                     'label_window': '1 day',
-                    'example_frequency': '1 days'
+                    'example_frequency': '1 days',
+                    'train_duration': '5 days'
                 },
                 'test_matrices': [{
                     'matrix_start_time': datetime.datetime(2010, 1, 8, 0, 0),

--- a/timechop/timechop.py
+++ b/timechop/timechop.py
@@ -132,7 +132,8 @@ class Timechop(object):
                 'matrix_end_time': train_matrix_end_time,
                 'as_of_times': train_as_of_times,
                 'label_window': train_label_window,
-                'example_frequency': self.train_example_frequency
+                'example_frequency': self.train_example_frequency,
+                'train_duration': train_duration
             },
             'test_matrices': test_matrices
         }


### PR DESCRIPTION
For now, I'd like to merge this in, as triage requires it, until we are able to refactor into matrix groups.