### PR TITLE
Select Entities from Entities Table:

### DIFF
--- a/tests/test_architect.py
+++ b/tests/test_architect.py
@@ -20,6 +20,39 @@ import pytest
 
 # make some fake features data
 
+states = [
+    [0, '2016-02-01', False, True],
+    [0, '2016-02-01', False, True],
+    [0, '2016-03-01', False, True],
+    [0, '2016-04-01', False, True],
+    [0, '2016-05-01', False, True],
+    [1, '2016-01-01', True, False],
+    [1, '2016-02-01', True, False],
+    [1, '2016-03-01', True, False],
+    [1, '2016-04-01', True, False],
+    [1, '2016-05-01', True, False],
+    [2, '2016-01-01', True, False],
+    [2, '2016-02-01', True, True],
+    [2, '2016-03-01', True, False],
+    [2, '2016-04-01', True, True],
+    [2, '2016-05-01', True, False],
+    [3, '2016-01-01', False, True],
+    [3, '2016-02-01', True, True],
+    [3, '2016-03-01', False, True],
+    [3, '2016-04-01', True, True],
+    [3, '2016-05-01', False, True],
+    [4, '2016-01-01', True, True],
+    [4, '2016-02-01', True, True],
+    [4, '2016-03-01', True, True],
+    [4, '2016-04-01', True, True],
+    [4, '2016-05-01', True, True],
+    [5, '2016-01-01', False, False],
+    [5, '2016-02-01', False, False],
+    [5, '2016-03-01', False, False],
+    [5, '2016-04-01', False, False],
+    [5, '2016-05-01', False, False]
+]
+
 features0 = [
     [0, '2016-01-01', 2, 0],
     [1, '2016-01-01', 1, 2],
@@ -39,7 +72,10 @@ features1 = [
     [0, '2016-03-01', 3, 3],
     [1, '2016-03-01', 3, 4],
     [2, '2016-03-01', 3, 3],
-    [3, '2016-03-01', 3, 4]
+    [3, '2016-03-01', 3, 4],
+    [0, '2016-03-01', 3, 3],
+    [4, '2016-03-01', 1, 4],
+    [5, '2016-03-01', 2, 4]
 ] 
 
 features_tables = [features0, features1]
@@ -86,6 +122,26 @@ labels = [
     [3, '2016-03-01', '1 month', 'ems',     'binary', 0],
     [3, '2016-04-01', '1 month', 'ems',     'binary', 1],
     [3, '2016-05-01', '1 month', 'ems',     'binary', 0],
+    [4, '2016-01-01', '1 month', 'booking', 'binary', 1],
+    [4, '2016-02-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-03-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-04-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-05-01', '1 month', 'booking', 'binary', 0],
+    [4, '2016-01-01', '1 month', 'ems',     'binary', 0],
+    [4, '2016-02-01', '1 month', 'ems',     'binary', 1],
+    [4, '2016-03-01', '1 month', 'ems',     'binary', 0],
+    [4, '2016-04-01', '1 month', 'ems',     'binary', 1],
+    [4, '2016-05-01', '1 month', 'ems',     'binary', 1],
+    [5, '2016-01-01', '1 month', 'booking', 'binary', 1],
+    [5, '2016-02-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-03-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-04-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-05-01', '1 month', 'booking', 'binary', 0],
+    [5, '2016-01-01', '1 month', 'ems',     'binary', 0],
+    [5, '2016-02-01', '1 month', 'ems',     'binary', 1],
+    [5, '2016-03-01', '1 month', 'ems',     'binary', 0],
+    [5, '2016-04-01', '1 month', 'ems',     'binary', 0],
+    [5, '2016-05-01', '1 month', 'ems',     'binary', 0],
     [0, '2016-02-01', '3 month', 'booking', 'binary', 0],
     [0, '2016-03-01', '3 month', 'booking', 'binary', 0],
     [0, '2016-04-01', '3 month', 'booking', 'binary', 0],
@@ -124,7 +180,27 @@ labels = [
     [3, '2016-02-01', '3 month', 'ems',     'binary', 0],
     [3, '2016-03-01', '3 month', 'ems',     'binary', 0],
     [3, '2016-04-01', '3 month', 'ems',     'binary', 1],
-    [3, '2016-05-01', '3 month', 'ems',     'binary', 0]
+    [3, '2016-05-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [4, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [4, '2016-03-01', '3 month', 'booking', 'binary', 1],
+    [4, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [4, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [4, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-04-01', '3 month', 'ems',     'binary', 0],
+    [4, '2016-05-01', '3 month', 'ems',     'binary', 1],
+    [5, '2016-01-01', '3 month', 'booking', 'binary', 0],
+    [5, '2016-02-01', '3 month', 'booking', 'binary', 0],
+    [5, '2016-03-01', '3 month', 'booking', 'binary', 1],
+    [5, '2016-04-01', '3 month', 'booking', 'binary', 0],
+    [5, '2016-05-01', '3 month', 'booking', 'binary', 1],
+    [5, '2016-01-01', '3 month', 'ems',     'binary', 0],
+    [5, '2016-02-01', '3 month', 'ems',     'binary', 0],
+    [5, '2016-03-01', '3 month', 'ems',     'binary', 0],
+    [5, '2016-04-01', '3 month', 'ems',     'binary', 1],
+    [5, '2016-05-01', '3 month', 'ems',     'binary', 0]
 ]
 
 label_name = 'booking'
@@ -134,7 +210,7 @@ db_config = {
     'features_schema_name': 'features',
     'labels_schema_name': 'labels',
     'labels_table_name': 'labels',
-    'entities_table_name': 'staging.entities'
+    'sparse_state_table_name': 'staging.sparse_states'
 }
 
 def test_build_labels_query():
@@ -144,12 +220,6 @@ def test_build_labels_query():
     # set up labeling config variables
     dates = [datetime.datetime(2016, 1, 1, 0, 0),
              datetime.datetime(2016, 2, 1, 0, 0)]
-    entities = [0, 1, 3]
-
-    with testing.postgresql.Postgresql() as postgresql:
-        # create an engine and generate a table with fake feature data
-        engine = create_engine(postgresql.url())
-        create_schemas(engine, features_tables, labels, entities)
 
     # make a dataframe of labels to test against
     labels_df = pd.DataFrame(
@@ -163,8 +233,22 @@ def test_build_labels_query():
             'label'
         ]
     )
+    states_df = pd.DataFrame(
+        states,
+        columns = [
+            'entity_id',
+            'as_of_date',
+            'state_one',
+            'state_two'
+        ]
+    ).set_index(['entity_id', 'as_of_date'])
+    labels_df = labels_df[
+        states_df['entity_id'] == labels_df['entity_id'] &
+        states_df['as_of_date'] == labels_df['as_of_date'] &
+        states_df['state_one'] &
+        states_df['state_two']
+    ]
     labels_df['as_of_date'] = convert_string_column_to_date(labels_df['as_of_date'])
-    labels_df = labels_df[labels_df['entity_id'].isin(entities)]
     
     # create an engine and generate a table with fake feature data
     with testing.postgresql.Postgresql() as postgresql:
@@ -173,17 +257,18 @@ def test_build_labels_query():
             engine=engine,
             features_tables=features_tables,
             labels=labels,
-            entities=entities
+            states=states
         )
         with TemporaryDirectory() as temp_dir:
             architect = Architect(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine
+                beginning_of_time=datetime.datetime(2010, 1, 1, 0, 0),
+                label_names=['booking'],
+                label_types=['binary'],
+                states=['state_one AND state_two'],
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                user_metadata={},
+                engine=engine
             )       
 
             # get the queries and test them
@@ -218,7 +303,6 @@ def test_write_to_csv():
     """ Test the write_to_csv function by checking whether the csv contains the
     correct number of lines.
     """
-    entities = [0, 2, 3]
     with testing.postgresql.Postgresql() as postgresql:
         # create an engine and generate a table with fake feature data
         engine = create_engine(postgresql.url())
@@ -226,19 +310,19 @@ def test_write_to_csv():
             engine=engine,
             features_tables=features_tables,
             labels=labels,
-            entities=entities
+            states=states
         )
-
         with TemporaryDirectory() as temp_dir:
             architect = Architect(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine,
-                builder_class = builders.LowMemoryCSVBuilder
+                beginning_of_time=datetime.datetime(2010, 1, 1, 0, 0),
+                label_names=['booking'],
+                label_types=['binary'],
+                states=['state_one AND state_two'],
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                user_metadata={},
+                engine=engine,
+                builder_class=builders.LowMemoryCSVBuilder
             )
 
             # for each table, check that corresponding csv has the correct # of rows
@@ -259,21 +343,22 @@ def test_make_entity_date_table():
     """ Test that the make_entity_date_table function contains the correct
     values.
     """
-    dates = [datetime.datetime(2016, 1, 1, 0, 0),
-             datetime.datetime(2016, 2, 1, 0, 0),
-             datetime.datetime(2016, 3, 1, 0, 0)]
-
-    entities = [0, 1, 2]
+    dates = [
+        datetime.datetime(2016, 1, 1, 0, 0),
+        datetime.datetime(2016, 2, 1, 0, 0),
+        datetime.datetime(2016, 3, 1, 0, 0)
+    ]
 
     # make a dataframe of entity ids and dates to test against
     ids_dates = create_entity_date_df(
-        dates,
-        labels,
-        dates,
-        entities,
-        'booking',
-        'binary',
-        '1 month'
+        labels=labels,
+        states=states,
+        as_of_dates=dates,
+        state_one=True,
+        state_two=True,
+        label_name='booking',
+        label_type='binary',
+        label_window='1 month'
     )
 
     with testing.postgresql.Postgresql() as postgresql:
@@ -283,27 +368,29 @@ def test_make_entity_date_table():
             engine=engine,
             features_tables=features_tables,
             labels=labels,
-            entities=entities
+            states=states
         )
 
         with TemporaryDirectory() as temp_dir:
             architect = Architect(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine
+                beginning_of_time=datetime.datetime(2010, 1, 1, 0, 0),
+                label_names=['booking'],
+                label_types=['binary'],
+                states=['state_one AND state_two'],
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                user_metadata={},
+                engine=engine
             )
             engine.execute(
-                'CREATE TABLE features.tmp_entity_date (a int, b date);'
+                'CREATE TEMPORARY TABLE tmp_entity_date (a int, b date);'
             )
             # call the function to test the creation of the table
             entity_date_table_name = architect.builder.make_entity_date_table(
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
+                state='state_one AND state_two',
                 matrix_uuid='my_uuid',
                 matrix_type='train',
                 label_window='1 month'
@@ -339,19 +426,21 @@ def test_make_entity_date_table():
 def test_build_outer_join_query():
     """ 
     """
-    dates = [datetime.datetime(2016, 1, 1, 0, 0),
-             datetime.datetime(2016, 2, 1, 0, 0)]
+    dates = [
+        datetime.datetime(2016, 1, 1, 0, 0),
+        datetime.datetime(2016, 2, 1, 0, 0)
+    ]
 
-    entities = [1, 2, 3]
     # make dataframe for entity ids and dates
     ids_dates = create_entity_date_df(
-        dates,
-        labels,
-        dates,
-        entities,
-        'booking',
-        'binary',
-        '1 month'
+        labels=labels,
+        states=states,
+        as_of_dates=dates,
+        state_one=True,
+        state_two=True,
+        label_name='booking',
+        label_type='binary',
+        label_window='1 month'
     )
 
     features = [['f1', 'f2'], ['f3', 'f4']]
@@ -379,17 +468,18 @@ def test_build_outer_join_query():
             engine=engine,
             features_tables=features_tables,
             labels=labels,
-            entities=entities
+            states=states
         )
         with TemporaryDirectory() as temp_dir:
             architect = Architect(
-                beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine
+                beginning_of_time=datetime.datetime(2010, 1, 1, 0, 0),
+                label_names=['booking'],
+                label_types=['binary'],
+                states=['state_one AND state_two'],
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                user_metadata={},
+                engine=engine
             )
 
             # make the entity-date table
@@ -397,6 +487,7 @@ def test_build_outer_join_query():
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
+                state='state_one AND state_two',
                 matrix_type='train',
                 matrix_uuid='my_uuid',
                 label_window='1 month'
@@ -406,6 +497,7 @@ def test_build_outer_join_query():
             for table_number, df in enumerate(features_dfs):
                 table_name = 'features{}'.format(table_number)
                 df = df.fillna(0)
+                df = df.reset_index()
                 query = architect.builder.build_outer_join_query(
                     as_of_times = dates,
                     right_table_name = 'features.{}'.format(table_name),
@@ -414,7 +506,7 @@ def test_build_outer_join_query():
                         features[table_number]
                     )
                 )
-                result = pd.read_sql(query, engine)
+                result = pd.read_sql(query, engine).reset_index()
                 test = (result == df)
                 assert(test.all().all())
 
@@ -425,6 +517,7 @@ class TestMergeFeatureCSVs(TestCase):
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
@@ -493,6 +586,7 @@ class TestMergeFeatureCSVs(TestCase):
                 beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                 label_names = ['booking'],
                 label_types = ['binary'],
+                states = ['state_one AND state_two'],
                 db_config = db_config,
                 matrix_directory = temp_dir,
                 user_metadata = {},
@@ -603,6 +697,7 @@ def test_generate_plans():
         beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
         label_names = ['booking'],
         label_types = ['binary'],
+        states = ['state_one AND state_two'],
         db_config = db_config,
         user_metadata = {},
         matrix_directory = '', # this test won't write anything
@@ -637,7 +732,6 @@ class TestBuildMatrix(object):
             datetime.datetime(2016, 2, 1, 0, 0),
             datetime.datetime(2016, 3, 1, 0, 0)
         ]
-        entities = [0, 1, 2]
         with testing.postgresql.Postgresql() as postgresql:
             # create an engine and generate a table with fake feature data
             engine = create_engine(postgresql.url())
@@ -645,7 +739,7 @@ class TestBuildMatrix(object):
                 engine=engine,
                 features_tables=features_tables,
                 labels=labels,
-                entities=entities
+                states=states
             )
 
             with TemporaryDirectory() as temp_dir:
@@ -653,6 +747,7 @@ class TestBuildMatrix(object):
                     beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
+                    states = ['state_one AND state_two'],
                     db_config = db_config,
                     matrix_directory = temp_dir,
                     user_metadata = {},
@@ -667,18 +762,19 @@ class TestBuildMatrix(object):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_window': '1 month',
+                    'state': 'state_one AND state_two'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'train'
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='train'
                 )
 
                 matrix_filename = os.path.join(
@@ -695,7 +791,6 @@ class TestBuildMatrix(object):
             datetime.datetime(2016, 2, 1, 0, 0),
             datetime.datetime(2016, 3, 1, 0, 0)
         ]
-        entities = [0, 1, 3]
 
         with testing.postgresql.Postgresql() as postgresql:
             # create an engine and generate a table with fake feature data
@@ -704,7 +799,7 @@ class TestBuildMatrix(object):
                 engine=engine,
                 features_tables=features_tables,
                 labels=labels,
-                entities=entities
+                states=states
             )
 
             with TemporaryDirectory() as temp_dir:
@@ -712,6 +807,7 @@ class TestBuildMatrix(object):
                     beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
+                    states = ['state_one AND state_two'],
                     db_config = db_config,
                     matrix_directory = temp_dir,
                     user_metadata = {},
@@ -732,18 +828,19 @@ class TestBuildMatrix(object):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_window': '1 month',
+                    'state': 'state_one AND state_two'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'test'
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='test'
                 )
                 print(os.listdir(temp_dir))
                 matrix_filename = os.path.join(
@@ -761,7 +858,6 @@ class TestBuildMatrix(object):
             datetime.datetime(2016, 2, 1, 0, 0),
             datetime.datetime(2016, 3, 1, 0, 0)
         ]
-        entities = [0, 2, 3]
 
         with testing.postgresql.Postgresql() as postgresql:
             # create an engine and generate a table with fake feature data
@@ -770,7 +866,7 @@ class TestBuildMatrix(object):
                 engine=engine,
                 features_tables=features_tables,
                 labels=labels,
-                entities=entities
+                states=states
             )
 
             with TemporaryDirectory() as temp_dir:
@@ -778,6 +874,7 @@ class TestBuildMatrix(object):
                     beginning_of_time = datetime.datetime(2010, 1, 1, 0, 0),
                     label_names = ['booking'],
                     label_types = ['binary'],
+                    states = ['state_one AND state_two'],
                     db_config = db_config,
                     matrix_directory = temp_dir,
                     user_metadata = {},
@@ -799,18 +896,19 @@ class TestBuildMatrix(object):
                     'label_name': 'booking',
                     'end_time': datetime.datetime(2016, 3, 1, 0, 0),
                     'beginning_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'label_window': '1 month'
+                    'label_window': '1 month',
+                    'state': 'state_one AND state_two'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 architect.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'test'
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='test'
                 )
 
                 matrix_filename = os.path.join(
@@ -825,13 +923,13 @@ class TestBuildMatrix(object):
                 # rerun
                 architect.builder.make_entity_date_table = Mock()
                 architect.builder.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'test'
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='test'
                 )
                 assert not architect.builder.make_entity_date_table.called

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,7 +11,7 @@ def convert_string_column_to_date(column):
         [datetime.datetime.strptime(date, '%Y-%m-%d').date() for date in column]
     )
 
-def create_features_and_labels_schemas(engine, features_tables, labels):
+def create_schemas(engine, features_tables, labels, entities):
     """ This function makes a features schema and populates it with the fake
     data from above.
 
@@ -41,6 +41,18 @@ def create_features_and_labels_schemas(engine, features_tables, labels):
             'insert into labels.labels values (%s, %s, %s, %s, %s, %s)',
             row
         )
+    # create entities table
+    engine.execute('drop table if exists staging cascade; create schema staging;')
+    engine.execute(
+        """
+            create table staging.entities (
+                entity_id int
+            )
+        """
+    )
+    for entity in entities:
+        engine.execute('insert into staging.entities values (%s)', entity)
+
 
 def create_features_table(table_number, table, engine):
     engine.execute(
@@ -62,6 +74,7 @@ def create_entity_date_df(
     dates,
     labels,
     as_of_dates,
+    entities,
     label_name,
     label_type,
     label_window
@@ -89,6 +102,7 @@ def create_entity_date_df(
         '%Y-%m-%d'
     ).date() for date in ids_dates['as_of_date']]
     ids_dates = ids_dates[ids_dates['as_of_date'].isin(dates)]
+    ids_dates = ids_dates[ids_dates['entity_id'].isin(entities)]
     print(ids_dates)
     print(dates)
 

--- a/timechop/architect.py
+++ b/timechop/architect.py
@@ -11,12 +11,23 @@ from . import builders, utils
 
 class Architect(object):
 
-    def __init__(self, beginning_of_time, label_names, label_types, db_config,
-                 matrix_directory, user_metadata, engine,
-                 builder_class=builders.HighMemoryCSVBuilder, replace=True):
+    def __init__(
+        self,
+        beginning_of_time,
+        label_names,
+        label_types,
+        states,
+        db_config,
+        matrix_directory,
+        user_metadata,
+        engine,
+        builder_class=builders.HighMemoryCSVBuilder,
+        replace=True
+    ):
         self.beginning_of_time = beginning_of_time # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
+        self.states = states
         self.db_config = db_config
         self.matrix_directory = matrix_directory
         self.user_metadata = user_metadata
@@ -47,8 +58,15 @@ class Architect(object):
             'matrix_type': matrix_metadata['matrix_type']
         }
 
-    def _make_metadata(self, matrix_definition, feature_dictionary, label_name,
-                       label_type, matrix_type):
+    def _make_metadata(
+        self,
+        matrix_definition,
+        feature_dictionary,
+        label_name,
+        label_type,
+        state,
+        matrix_type
+    ):
         """ Generate dictionary of matrix metadata.
 
         :param matrix_definition: temporal definition of matrix
@@ -86,6 +104,7 @@ class Architect(object):
 
             # other information
             'label_type': label_type,
+            'state': state,
             'matrix_id': matrix_id,
             'matrix_type': matrix_type
 
@@ -113,9 +132,10 @@ class Architect(object):
         build_tasks = dict()
         for matrix_set in matrix_set_definitions:
             train_matrix = matrix_set['train_matrix']
-            for label_name, label_type, feature_dictionary in itertools.product(
+            for label_name, label_type, state, feature_dictionary in itertools.product(
                 self.label_names,
                 self.label_types,
+                self.states,
                 feature_dictionaries
             ):
                 matrix_set_clone = copy.deepcopy(matrix_set)
@@ -125,6 +145,7 @@ class Architect(object):
                     feature_dictionary,
                     label_name,
                     label_type,
+                    state,
                     'train',
                 )
                 train_uuid = metta.generate_uuid(train_metadata)
@@ -144,6 +165,7 @@ class Architect(object):
                         feature_dictionary,
                         label_name,
                         label_type,
+                        state,
                         'test',
                     )
                     test_uuid = metta.generate_uuid(test_metadata)


### PR DESCRIPTION
If merged, this commit will:

- change the logic for creating entity-date sets so that for train sets, it filters the labels against and entities table and for test sets, it creates a cross join of all entities in the entities table and the dates for the matrix [Resolves #69]
- creates entity date tables as temporary tables [Resolves #60], [Resolves #51]
- reformats entity date table names so that uuid is last [Resolves #50]